### PR TITLE
Scrape card pics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 # package directories
 node_modules
 jspm_packages
+.DS_Store
 
 # Serverless directories
 .serverless
 .env
+
+images

--- a/cards.json
+++ b/cards.json
@@ -1,5 +1,55 @@
 [
   {
+    "productName": "500 Years in the Future - Booster Box",
+    "setName": [
+      "500 Years in the Future"
+    ],
+    "rarityName": [
+      "None"
+    ],
+    "marketPrice": 197.92,
+    "lowestPriceWithShipping": 197.67,
+    "number": null,
+    "productId": 532106
+  },
+  {
+    "productName": "500 Years in the Future - Booster Box Case",
+    "setName": [
+      "500 Years in the Future"
+    ],
+    "rarityName": [
+      "None"
+    ],
+    "marketPrice": 1988.87,
+    "lowestPriceWithShipping": 2299.63,
+    "number": null,
+    "productId": 532107
+  },
+  {
+    "productName": "500 Years in the Future - Booster Pack",
+    "setName": [
+      "500 Years in the Future"
+    ],
+    "rarityName": [
+      "None"
+    ],
+    "marketPrice": 9.45,
+    "lowestPriceWithShipping": 9.92,
+    "number": null,
+    "productId": 532104
+  },
+  {
+    "productName": "500 Years in the Future - Sleeved Booster Pack",
+    "setName": [
+      "500 Years in the Future"
+    ],
+    "rarityName": [
+      "None"
+    ],
+    "number": null,
+    "productId": 532105
+  },
+  {
     "productName": "Adio",
     "setName": [
       "Pillars of Strength"
@@ -7,7 +57,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -32,8 +82,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.18,
-    "lowestPriceWithShipping": 1.1,
+    "marketPrice": 1.22,
+    "lowestPriceWithShipping": 1,
     "color": [
       "Red"
     ],
@@ -57,8 +107,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.4,
-    "lowestPriceWithShipping": 0.2,
+    "marketPrice": 1,
+    "lowestPriceWithShipping": 0.4,
     "color": [
       "Purple"
     ],
@@ -83,8 +133,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 11.26,
-    "lowestPriceWithShipping": 9.44,
+    "marketPrice": 10.5,
+    "lowestPriceWithShipping": 11.02,
     "color": [
       "Black"
     ],
@@ -106,8 +156,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.18,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.21,
+    "lowestPriceWithShipping": 0.09,
     "color": [
       "Black"
     ],
@@ -129,8 +179,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.45,
-    "lowestPriceWithShipping": 0.35,
+    "marketPrice": 0.5,
+    "lowestPriceWithShipping": 0.5,
     "color": [
       "Green"
     ],
@@ -155,7 +205,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -181,8 +231,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.15,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.19,
+    "lowestPriceWithShipping": 0.08,
     "color": [
       "Blue"
     ],
@@ -206,8 +256,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 5.31,
-    "lowestPriceWithShipping": 5.9,
+    "marketPrice": 7.59,
+    "lowestPriceWithShipping": 6,
     "color": [
       "Blue"
     ],
@@ -231,8 +281,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 8.98,
-    "lowestPriceWithShipping": 8,
+    "marketPrice": 5.6,
+    "lowestPriceWithShipping": 5.23,
     "color": [
       "Yellow"
     ],
@@ -256,7 +306,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.1,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
@@ -281,7 +331,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.11,
+    "marketPrice": 0.12,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -307,7 +357,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.11,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
@@ -332,7 +382,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.13,
+    "marketPrice": 1.04,
     "lowestPriceWithShipping": 0.5,
     "color": [
       "Blue"
@@ -357,8 +407,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 4.54,
-    "lowestPriceWithShipping": 3.92,
+    "marketPrice": 4.23,
+    "lowestPriceWithShipping": 4.01,
     "color": [
       "Blue"
     ],
@@ -381,8 +431,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.41,
-    "lowestPriceWithShipping": 0.25,
+    "marketPrice": 0.32,
+    "lowestPriceWithShipping": 0.28,
     "color": [
       "Blue"
     ],
@@ -405,8 +455,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.11,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.1,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Blue"
     ],
@@ -431,7 +481,7 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.1,
+    "marketPrice": 0.16,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Green",
@@ -459,8 +509,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 52.42,
-    "lowestPriceWithShipping": 54,
+    "marketPrice": 70.61,
+    "lowestPriceWithShipping": 61.39,
     "color": null,
     "cardType": [
       "Leader"
@@ -480,7 +530,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 10.76,
+    "marketPrice": 16.97,
+    "lowestPriceWithShipping": 14,
     "color": [
       "Blue"
     ],
@@ -505,7 +556,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.1,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -530,7 +581,7 @@
       "Uncommon"
     ],
     "marketPrice": 0.11,
-    "lowestPriceWithShipping": 0.03,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Green"
     ],
@@ -555,8 +606,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 4.67,
-    "lowestPriceWithShipping": 6.5,
+    "marketPrice": 4.21,
+    "lowestPriceWithShipping": 3.59,
     "color": [
       "Red"
     ],
@@ -580,7 +631,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.09,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Red"
@@ -605,8 +656,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 19.75,
-    "lowestPriceWithShipping": 20.84,
+    "marketPrice": 29.29,
+    "lowestPriceWithShipping": 27.69,
     "number": null,
     "productId": 520771
   },
@@ -618,8 +669,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 193.07,
-    "lowestPriceWithShipping": 193.5,
+    "marketPrice": 263.6,
+    "lowestPriceWithShipping": 266,
     "number": null,
     "productId": 498734
   },
@@ -631,8 +682,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 2056.95,
-    "lowestPriceWithShipping": 2769.69,
+    "marketPrice": 3061.98,
+    "lowestPriceWithShipping": 2739,
     "number": null,
     "productId": 498735
   },
@@ -644,8 +695,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 6.09,
-    "lowestPriceWithShipping": 5.35,
+    "marketPrice": 8.13,
+    "lowestPriceWithShipping": 8.73,
     "number": null,
     "productId": 498733
   },
@@ -657,8 +708,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 6.33,
-    "lowestPriceWithShipping": 14,
+    "marketPrice": 13.52,
+    "lowestPriceWithShipping": 16,
     "number": null,
     "productId": 531575
   },
@@ -670,8 +721,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.06,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
     ],
@@ -694,7 +745,7 @@
       "Common"
     ],
     "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.01,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Purple"
     ],
@@ -719,8 +770,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 5.94,
-    "lowestPriceWithShipping": 10.95,
+    "marketPrice": 9.21,
+    "lowestPriceWithShipping": 8.91,
     "color": [
       "Green"
     ],
@@ -744,8 +795,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.17,
+    "lowestPriceWithShipping": 0.09,
     "color": [
       "Green"
     ],
@@ -769,8 +820,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 5.58,
-    "lowestPriceWithShipping": 4.4,
+    "marketPrice": 3.93,
+    "lowestPriceWithShipping": 2.8,
     "color": [
       "Green"
     ],
@@ -794,8 +845,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.08,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.06,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
     ],
@@ -819,8 +870,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.1984,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.39,
+    "lowestPriceWithShipping": 0.16,
     "color": [
       "Green"
     ],
@@ -844,8 +895,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 31.4,
-    "lowestPriceWithShipping": 30.98,
+    "marketPrice": 31.26,
+    "lowestPriceWithShipping": 29.49,
     "color": [
       "Green"
     ],
@@ -869,8 +920,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.12,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.1,
+    "lowestPriceWithShipping": 0.07,
     "color": [
       "Purple"
     ],
@@ -888,6 +939,54 @@
     "productId": 479848
   },
   {
+    "productName": "Backlight",
+    "setName": [
+      "Starter Deck 11 Uta"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 1.07,
+    "lowestPriceWithShipping": 0.95,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Event"
+    ],
+    "attribute": null,
+    "subtypes": [
+      "FILM",
+      "Music"
+    ],
+    "number": "ST11-003",
+    "productId": 533881
+  },
+  {
+    "productName": "Backlight (Starter Deck 11: Uta Deck Battle)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 27.25,
+    "lowestPriceWithShipping": 21.99,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Event"
+    ],
+    "attribute": null,
+    "subtypes": [
+      "FILM",
+      "Music"
+    ],
+    "number": "ST11-003",
+    "productId": 532110
+  },
+  {
     "productName": "Bad Manners Kick Course",
     "setName": [
       "Kingdoms of Intrigue"
@@ -895,7 +994,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.21,
+    "marketPrice": 0.3,
     "lowestPriceWithShipping": 0.1,
     "color": [
       "Red"
@@ -919,7 +1018,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.04,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -944,8 +1043,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.46,
-    "lowestPriceWithShipping": 0.25,
+    "marketPrice": 0.47,
+    "lowestPriceWithShipping": 0.46,
     "color": [
       "Purple"
     ],
@@ -969,7 +1068,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.04,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -995,8 +1094,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.09,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Yellow"
     ],
@@ -1020,8 +1119,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.09,
+    "marketPrice": 0.15,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Blue"
     ],
@@ -1043,8 +1142,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.52,
-    "lowestPriceWithShipping": 0.86,
+    "marketPrice": 1.41,
+    "lowestPriceWithShipping": 0.85,
     "color": [
       "Black"
     ],
@@ -1067,7 +1166,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -1092,7 +1191,7 @@
       "Uncommon"
     ],
     "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.02,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Blue"
     ],
@@ -1118,7 +1217,7 @@
       "Common"
     ],
     "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.02,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Blue"
     ],
@@ -1143,8 +1242,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.67,
-    "lowestPriceWithShipping": 0.6,
+    "marketPrice": 0.69,
+    "lowestPriceWithShipping": 0.49,
     "color": [
       "Blue"
     ],
@@ -1169,7 +1268,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.26,
+    "marketPrice": 0.31,
     "lowestPriceWithShipping": 0.2,
     "color": [
       "Blue"
@@ -1195,7 +1294,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.1,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -1222,7 +1321,7 @@
       "Rare"
     ],
     "marketPrice": 0.42,
-    "lowestPriceWithShipping": 0.2,
+    "lowestPriceWithShipping": 0.18,
     "color": [
       "Blue"
     ],
@@ -1247,8 +1346,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 18.06,
-    "lowestPriceWithShipping": 14.5,
+    "marketPrice": 12.18,
+    "lowestPriceWithShipping": 9.97,
     "color": [
       "Red"
     ],
@@ -1273,8 +1372,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.48,
-    "lowestPriceWithShipping": 0.18,
+    "marketPrice": 0.35,
+    "lowestPriceWithShipping": 0.2,
     "color": [
       "Black"
     ],
@@ -1299,8 +1398,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.12,
-    "lowestPriceWithShipping": 0.03,
+    "marketPrice": 0.09,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Red"
     ],
@@ -1318,6 +1417,33 @@
     "productId": 454542
   },
   {
+    "productName": "Bartolomeo (CS 2023 Event Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 70.29,
+    "lowestPriceWithShipping": 73,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Special"
+    ],
+    "subtypes": [
+      "FILM",
+      "Supernovas",
+      "Barto Club"
+    ],
+    "number": "P-029",
+    "productId": 525300
+  },
+  {
     "productName": "Bartolomeo (Event Pack Vol. 1)",
     "setName": [
       "One Piece Promotion Cards"
@@ -1325,8 +1451,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 43.82,
-    "lowestPriceWithShipping": 40.99,
+    "marketPrice": 71.72,
+    "lowestPriceWithShipping": 70.5,
     "color": [
       "Green"
     ],
@@ -1352,8 +1478,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 0.53,
-    "lowestPriceWithShipping": 0.26,
+    "marketPrice": 0.57,
+    "lowestPriceWithShipping": 0.38,
     "color": [
       "Red"
     ],
@@ -1379,8 +1505,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 4.87,
-    "lowestPriceWithShipping": 5.74,
+    "marketPrice": 3.5,
+    "lowestPriceWithShipping": 2.49,
     "color": [
       "Blue"
     ],
@@ -1405,8 +1531,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.28,
-    "lowestPriceWithShipping": 0.99,
+    "marketPrice": 0.44,
+    "lowestPriceWithShipping": 0.23,
     "color": [
       "Purple"
     ],
@@ -1431,8 +1557,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.18,
-    "lowestPriceWithShipping": 2,
+    "marketPrice": 3.15,
+    "lowestPriceWithShipping": 2.25,
     "color": [
       "Green"
     ],
@@ -1457,8 +1583,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 4.52,
-    "lowestPriceWithShipping": 2.37,
+    "marketPrice": 4.02,
+    "lowestPriceWithShipping": 3.24,
     "color": [
       "Green"
     ],
@@ -1483,8 +1609,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.03,
+    "marketPrice": 0.08,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
     ],
@@ -1502,6 +1628,80 @@
     "productId": 528603
   },
   {
+    "productName": "Basil Hawkins (CS 2023 Top Players Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "lowestPriceWithShipping": 2500,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Hawkins Pirates",
+      "Supernovas"
+    ],
+    "number": "ST02-010",
+    "productId": 525683
+  },
+  {
+    "productName": "Basil Hawkins (CS 2023 Top Players Pack) [Finalist]",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "lowestPriceWithShipping": 5250,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Hawkins Pirates",
+      "Supernovas"
+    ],
+    "number": "ST02-010",
+    "productId": 525684
+  },
+  {
+    "productName": "Basil Hawkins (CS 2023 Top Players Pack) [Winner]",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Hawkins Pirates",
+      "Supernovas"
+    ],
+    "number": "ST02-010",
+    "productId": 525685
+  },
+  {
     "productName": "Bastille",
     "setName": [
       "Awakening of the New Era"
@@ -1509,8 +1709,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.12,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.09,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Blue"
     ],
@@ -1534,8 +1734,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 9.76,
-    "lowestPriceWithShipping": 7.71,
+    "marketPrice": 4.38,
+    "lowestPriceWithShipping": 2.5,
     "color": [
       "Blue"
     ],
@@ -1559,8 +1759,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.12,
-    "lowestPriceWithShipping": 0.06,
+    "marketPrice": 0.19,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Green"
     ],
@@ -1582,8 +1782,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.92,
-    "lowestPriceWithShipping": 0.78,
+    "marketPrice": 0.97,
+    "lowestPriceWithShipping": 0.77,
     "color": [
       "Black"
     ],
@@ -1607,8 +1807,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.18,
-    "lowestPriceWithShipping": 0.09,
+    "marketPrice": 0.21,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Blue"
     ],
@@ -1633,7 +1833,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.1,
+    "marketPrice": 0.11,
     "lowestPriceWithShipping": 0.03,
     "color": [
       "Black"
@@ -1658,8 +1858,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.65,
-    "lowestPriceWithShipping": 3.41,
+    "marketPrice": 3.24,
+    "lowestPriceWithShipping": 2.96,
     "color": [
       "Green"
     ],
@@ -1683,8 +1883,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.06,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
     ],
@@ -1733,8 +1933,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 3.47,
-    "lowestPriceWithShipping": 2.97,
+    "marketPrice": 4.22,
+    "lowestPriceWithShipping": 3.5,
     "color": [
       "Yellow"
     ],
@@ -1758,8 +1958,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.14,
-    "lowestPriceWithShipping": 0.08,
+    "marketPrice": 0.13,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Red",
       "Yellow"
@@ -1784,8 +1984,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 51.33,
-    "lowestPriceWithShipping": 53.89,
+    "marketPrice": 56.46,
+    "lowestPriceWithShipping": 49.86,
     "color": [
       "Red",
       "Yellow"
@@ -1810,8 +2010,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.39,
-    "lowestPriceWithShipping": 0.19,
+    "marketPrice": 0.42,
+    "lowestPriceWithShipping": 0.15,
     "color": [
       "Red"
     ],
@@ -1835,8 +2035,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 24.11,
-    "lowestPriceWithShipping": 24.36,
+    "marketPrice": 29.36,
+    "lowestPriceWithShipping": 25.77,
     "color": [
       "Red"
     ],
@@ -1860,8 +2060,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 0.36,
-    "lowestPriceWithShipping": 0.26,
+    "marketPrice": 0.42,
+    "lowestPriceWithShipping": 0.15,
     "color": [
       "Red"
     ],
@@ -1886,8 +2086,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.1,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Purple"
     ],
@@ -1912,8 +2112,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.19,
-    "lowestPriceWithShipping": 0.08,
+    "marketPrice": 0.23,
+    "lowestPriceWithShipping": 0.09,
     "color": [
       "Green"
     ],
@@ -1938,8 +2138,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.12,
-    "lowestPriceWithShipping": 0.08,
+    "marketPrice": 0.13,
+    "lowestPriceWithShipping": 0.07,
     "color": [
       "Purple"
     ],
@@ -1964,8 +2164,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.11,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.14,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Green"
     ],
@@ -2016,8 +2216,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 2.89,
-    "lowestPriceWithShipping": 2.5,
+    "marketPrice": 2.52,
+    "lowestPriceWithShipping": 2.14,
     "color": [
       "Red"
     ],
@@ -2043,8 +2243,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.16,
-    "lowestPriceWithShipping": 0.07,
+    "marketPrice": 0.22,
+    "lowestPriceWithShipping": 0.14,
     "color": [
       "Purple"
     ],
@@ -2069,8 +2269,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 7.45,
-    "lowestPriceWithShipping": 5.5,
+    "marketPrice": 4.64,
+    "lowestPriceWithShipping": 4.61,
     "color": [
       "Green"
     ],
@@ -2090,8 +2290,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.09,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
     ],
@@ -2111,8 +2311,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.39,
-    "lowestPriceWithShipping": 0.23,
+    "marketPrice": 0.32,
+    "lowestPriceWithShipping": 0.2,
     "color": [
       "Purple"
     ],
@@ -2161,8 +2361,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.12,
-    "lowestPriceWithShipping": 0.08,
+    "marketPrice": 0.16,
+    "lowestPriceWithShipping": 0.09,
     "color": [
       "Purple"
     ],
@@ -2186,7 +2386,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.34,
+    "marketPrice": 0.35,
     "lowestPriceWithShipping": 0.2,
     "color": [
       "Purple"
@@ -2211,7 +2411,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
@@ -2229,6 +2429,31 @@
     "productId": 516768
   },
   {
+    "productName": "Black Maria (CS 2023 Celebration Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 14.44,
+    "lowestPriceWithShipping": 13,
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Special"
+    ],
+    "subtypes": [
+      "Animal Kingdom Pirates"
+    ],
+    "number": "ST04-011",
+    "productId": 525336
+  },
+  {
     "productName": "Black Maria (Tournament Pack Vol. 2)",
     "setName": [
       "One Piece Promotion Cards"
@@ -2237,7 +2462,7 @@
       "Promo"
     ],
     "marketPrice": 0.52,
-    "lowestPriceWithShipping": 0.45,
+    "lowestPriceWithShipping": 0.19,
     "color": [
       "Purple"
     ],
@@ -2261,8 +2486,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 6.33,
-    "lowestPriceWithShipping": 7,
+    "marketPrice": 10.01,
+    "lowestPriceWithShipping": 6,
     "color": [
       "Purple"
     ],
@@ -2286,8 +2511,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 7.9,
-    "lowestPriceWithShipping": 4.5,
+    "marketPrice": 7.91,
+    "lowestPriceWithShipping": 4.1,
     "color": [
       "Red"
     ],
@@ -2311,7 +2536,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.1,
+    "marketPrice": 0.09,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -2336,8 +2561,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.1,
-    "lowestPriceWithShipping": 1.34,
+    "marketPrice": 2.01,
+    "lowestPriceWithShipping": 1.98,
     "color": [
       "Purple"
     ],
@@ -2360,8 +2585,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.16,
-    "lowestPriceWithShipping": 0.5,
+    "marketPrice": 1.65,
+    "lowestPriceWithShipping": 1.33,
     "color": [
       "Purple"
     ],
@@ -2384,7 +2609,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -2409,7 +2634,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.21,
+    "marketPrice": 1.03,
     "lowestPriceWithShipping": 0.75,
     "color": [
       "Red"
@@ -2434,8 +2659,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.14,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.18,
+    "lowestPriceWithShipping": 0.08,
     "color": [
       "Black"
     ],
@@ -2459,7 +2684,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -2485,7 +2710,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.6,
+    "marketPrice": 0.66,
     "lowestPriceWithShipping": 0.42,
     "color": [
       "Purple"
@@ -2511,8 +2736,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 5.27,
-    "lowestPriceWithShipping": 5.5,
+    "marketPrice": 5.64,
+    "lowestPriceWithShipping": 6.43,
     "color": [
       "Blue"
     ],
@@ -2537,8 +2762,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.17,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.16,
+    "lowestPriceWithShipping": 0.08,
     "color": [
       "Blue"
     ],
@@ -2564,8 +2789,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.87,
-    "lowestPriceWithShipping": 5,
+    "marketPrice": 4.38,
+    "lowestPriceWithShipping": 3.69,
     "color": [
       "Blue"
     ],
@@ -2590,8 +2815,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.7,
-    "lowestPriceWithShipping": 0.59,
+    "marketPrice": 1.97,
+    "lowestPriceWithShipping": 1.49,
     "color": [
       "Blue"
     ],
@@ -2616,8 +2841,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 7.24,
-    "lowestPriceWithShipping": 6.49,
+    "marketPrice": 11.57,
+    "lowestPriceWithShipping": 15.99,
     "color": [
       "Blue"
     ],
@@ -2643,8 +2868,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 4.78,
-    "lowestPriceWithShipping": 4.76,
+    "marketPrice": 10.35,
+    "lowestPriceWithShipping": 9.71,
     "color": [
       "Blue"
     ],
@@ -2670,8 +2895,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 5.51,
-    "lowestPriceWithShipping": 5.25,
+    "marketPrice": 10.79,
+    "lowestPriceWithShipping": 8,
     "color": [
       "Blue"
     ],
@@ -2697,8 +2922,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 4.05,
-    "lowestPriceWithShipping": 2,
+    "marketPrice": 10.84,
+    "lowestPriceWithShipping": 7.1,
     "color": [
       "Blue"
     ],
@@ -2724,8 +2949,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 101.92,
-    "lowestPriceWithShipping": 119,
+    "marketPrice": 142.13,
+    "lowestPriceWithShipping": 128,
     "color": [
       "Blue"
     ],
@@ -2750,8 +2975,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 98.08,
-    "lowestPriceWithShipping": 101.59,
+    "marketPrice": 160.98,
+    "lowestPriceWithShipping": 135,
     "color": [
       "Blue"
     ],
@@ -2801,8 +3026,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.54,
-    "lowestPriceWithShipping": 0.4,
+    "marketPrice": 0.55,
+    "lowestPriceWithShipping": 0.48,
     "color": [
       "Yellow"
     ],
@@ -2826,8 +3051,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.58,
-    "lowestPriceWithShipping": 14.99,
+    "marketPrice": 2.12,
+    "lowestPriceWithShipping": 9.94,
     "color": [
       "Blue"
     ],
@@ -2851,7 +3076,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.15,
+    "marketPrice": 0.1,
     "lowestPriceWithShipping": 0.06,
     "color": [
       "Blue"
@@ -2876,8 +3101,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.44,
-    "lowestPriceWithShipping": 0.19,
+    "marketPrice": 0.51,
+    "lowestPriceWithShipping": 0.25,
     "color": [
       "Blue"
     ],
@@ -2901,8 +3126,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.52,
-    "lowestPriceWithShipping": 1,
+    "marketPrice": 1.26,
+    "lowestPriceWithShipping": 0.6,
     "color": [
       "Blue"
     ],
@@ -2926,8 +3151,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 42.03,
-    "lowestPriceWithShipping": 39,
+    "marketPrice": 42.01,
+    "lowestPriceWithShipping": 40.76,
     "color": [
       "Black"
     ],
@@ -2951,8 +3176,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 24.03,
-    "lowestPriceWithShipping": 22.91,
+    "marketPrice": 26.32,
+    "lowestPriceWithShipping": 24,
     "color": [
       "Blue"
     ],
@@ -2976,8 +3201,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 96.3,
-    "lowestPriceWithShipping": 145,
+    "marketPrice": 121.8,
+    "lowestPriceWithShipping": 126.99,
     "color": [
       "Black"
     ],
@@ -3001,8 +3226,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 288.05,
-    "lowestPriceWithShipping": 750,
+    "marketPrice": 445.69,
+    "lowestPriceWithShipping": 833.88,
     "color": [
       "Black"
     ],
@@ -3021,13 +3246,26 @@
   {
     "productName": "Box Promotion Pack",
     "setName": [
+      "Romance Dawn"
+    ],
+    "rarityName": [
+      "None"
+    ],
+    "marketPrice": 24.98,
+    "lowestPriceWithShipping": 14.95,
+    "number": null,
+    "productId": 532645
+  },
+  {
+    "productName": "Box Promotion Pack",
+    "setName": [
       "Paramount War"
     ],
     "rarityName": [
       "None"
     ],
-    "marketPrice": 4.76,
-    "lowestPriceWithShipping": 6.48,
+    "marketPrice": 6.27,
+    "lowestPriceWithShipping": 11.49,
     "number": null,
     "productId": 488298
   },
@@ -3039,8 +3277,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.6,
-    "lowestPriceWithShipping": 0.48,
+    "marketPrice": 0.56,
+    "lowestPriceWithShipping": 0.5,
     "color": [
       "Purple"
     ],
@@ -3062,8 +3300,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.16,
-    "lowestPriceWithShipping": 0.07,
+    "marketPrice": 0.17,
+    "lowestPriceWithShipping": 0.09,
     "color": [
       "Purple"
     ],
@@ -3085,8 +3323,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 2,
-    "lowestPriceWithShipping": 1.5,
+    "marketPrice": 2.28,
+    "lowestPriceWithShipping": 1.95,
     "color": [
       "Black"
     ],
@@ -3110,8 +3348,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.45,
-    "lowestPriceWithShipping": 1.25,
+    "marketPrice": 2.46,
+    "lowestPriceWithShipping": 2.19,
     "color": [
       "Red"
     ],
@@ -3135,8 +3373,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.77,
-    "lowestPriceWithShipping": 2.7,
+    "marketPrice": 3.76,
+    "lowestPriceWithShipping": 2.97,
     "color": [
       "Red"
     ],
@@ -3160,8 +3398,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.5268,
-    "lowestPriceWithShipping": 0.38,
+    "marketPrice": 0.33,
+    "lowestPriceWithShipping": 0.14,
     "color": [
       "Red"
     ],
@@ -3185,8 +3423,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.89,
-    "lowestPriceWithShipping": 0.68,
+    "marketPrice": 0.33,
+    "lowestPriceWithShipping": 0.24,
     "color": [
       "Green"
     ],
@@ -3197,7 +3435,6 @@
       "Slash"
     ],
     "subtypes": [
-      "Film",
       "Straw Hat Crew"
     ],
     "number": "OP02-040",
@@ -3211,8 +3448,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 11.17,
-    "lowestPriceWithShipping": 10.69,
+    "marketPrice": 7.28,
+    "lowestPriceWithShipping": 6.98,
     "color": [
       "Red"
     ],
@@ -3230,6 +3467,31 @@
     "productId": 485269
   },
   {
+    "productName": "Brook (CS 2023 Celebration Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 46.72,
+    "lowestPriceWithShipping": 30.5,
+    "color": [
+      "Red"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Straw Hat Crew"
+    ],
+    "number": "ST01-011",
+    "productId": 525325
+  },
+  {
     "productName": "Brook (Judge Pack Vol. 2)",
     "setName": [
       "One Piece Promotion Cards"
@@ -3237,8 +3499,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 5.13,
-    "lowestPriceWithShipping": 4.24,
+    "marketPrice": 9.01,
+    "lowestPriceWithShipping": 8.76,
     "color": [
       "Green"
     ],
@@ -3263,8 +3525,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 6.75,
-    "lowestPriceWithShipping": 8.01,
+    "marketPrice": 14.39,
+    "lowestPriceWithShipping": 13.95,
     "color": [
       "Red"
     ],
@@ -3288,8 +3550,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.96,
-    "lowestPriceWithShipping": 0.94,
+    "marketPrice": 1.68,
+    "lowestPriceWithShipping": 1,
     "color": [
       "Red"
     ],
@@ -3313,8 +3575,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 16.31,
-    "lowestPriceWithShipping": 17.98,
+    "marketPrice": 23.42,
+    "lowestPriceWithShipping": 18.99,
     "color": [
       "Red"
     ],
@@ -3338,8 +3600,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 2.89,
-    "lowestPriceWithShipping": 2.86,
+    "marketPrice": 3.03,
+    "lowestPriceWithShipping": 3.08,
     "color": [
       "Green"
     ],
@@ -3364,8 +3626,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.09,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Green"
     ],
@@ -3390,8 +3652,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.74,
-    "lowestPriceWithShipping": 0.45,
+    "marketPrice": 1.39,
+    "lowestPriceWithShipping": 0.98,
     "color": [
       "Purple"
     ],
@@ -3416,8 +3678,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 6.49,
-    "lowestPriceWithShipping": 4.89,
+    "marketPrice": 3.4,
+    "lowestPriceWithShipping": 1.97,
     "color": [
       "Green"
     ],
@@ -3441,8 +3703,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.02,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
     ],
@@ -3466,8 +3728,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.03,
+    "marketPrice": 0.08,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Blue"
     ],
@@ -3492,8 +3754,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.84,
-    "lowestPriceWithShipping": 0.45,
+    "marketPrice": 1.48,
+    "lowestPriceWithShipping": 1,
     "color": [
       "Blue"
     ],
@@ -3518,7 +3780,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.37,
+    "marketPrice": 0.33,
     "lowestPriceWithShipping": 0.2,
     "color": [
       "Blue"
@@ -3544,7 +3806,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.49,
+    "marketPrice": 0.31,
     "lowestPriceWithShipping": 0.25,
     "color": [
       "Red"
@@ -3569,8 +3831,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 22.06,
-    "lowestPriceWithShipping": 14.92,
+    "marketPrice": 17.63,
+    "lowestPriceWithShipping": 14,
     "color": [
       "Red"
     ],
@@ -3594,8 +3856,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.99,
-    "lowestPriceWithShipping": 0.98,
+    "marketPrice": 1.01,
+    "lowestPriceWithShipping": 1,
     "color": [
       "Green"
     ],
@@ -3621,7 +3883,7 @@
       "Common"
     ],
     "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.01,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Green"
     ],
@@ -3646,8 +3908,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 22.56,
-    "lowestPriceWithShipping": 24.99,
+    "marketPrice": 39.74,
+    "lowestPriceWithShipping": 37.98,
     "color": [
       "Blue"
     ],
@@ -3672,8 +3934,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.34,
-    "lowestPriceWithShipping": 0.2,
+    "marketPrice": 0.45,
+    "lowestPriceWithShipping": 0.23,
     "color": [
       "Green"
     ],
@@ -3698,8 +3960,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 6.26,
-    "lowestPriceWithShipping": 6.3,
+    "marketPrice": 3.74,
+    "lowestPriceWithShipping": 3.44,
     "color": [
       "Red"
     ],
@@ -3723,8 +3985,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 20,
-    "lowestPriceWithShipping": 6.68,
+    "marketPrice": 4.02,
+    "lowestPriceWithShipping": 2,
     "color": [
       "Red"
     ],
@@ -3748,8 +4010,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.04,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
     ],
@@ -3773,8 +4035,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.16,
+    "lowestPriceWithShipping": 0.08,
     "color": [
       "Yellow"
     ],
@@ -3796,7 +4058,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Purple"
@@ -3821,7 +4083,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.54,
+    "marketPrice": 0.51,
     "lowestPriceWithShipping": 0.25,
     "color": [
       "Purple"
@@ -3846,8 +4108,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.09,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Blue"
     ],
@@ -3871,8 +4133,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.84,
-    "lowestPriceWithShipping": 1,
+    "marketPrice": 1.23,
+    "lowestPriceWithShipping": 1.5,
     "color": [
       "Blue"
     ],
@@ -3897,7 +4159,7 @@
       "Rare"
     ],
     "marketPrice": 0.17,
-    "lowestPriceWithShipping": 0.05,
+    "lowestPriceWithShipping": 0.07,
     "color": [
       "Blue"
     ],
@@ -3922,8 +4184,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.81,
-    "lowestPriceWithShipping": 0.9,
+    "marketPrice": 0.87,
+    "lowestPriceWithShipping": 0.88,
     "color": [
       "Yellow"
     ],
@@ -3947,7 +4209,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
@@ -3972,8 +4234,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.76,
-    "lowestPriceWithShipping": 1.59,
+    "marketPrice": 1.48,
+    "lowestPriceWithShipping": 1.24,
     "color": [
       "Green"
     ],
@@ -3998,8 +4260,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 1.5,
-    "lowestPriceWithShipping": 1.07,
+    "marketPrice": 2.06,
+    "lowestPriceWithShipping": 1.95,
     "color": [
       "Yellow"
     ],
@@ -4023,8 +4285,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.84,
-    "lowestPriceWithShipping": 2.49,
+    "marketPrice": 2.22,
+    "lowestPriceWithShipping": 1.5,
     "color": [
       "Green"
     ],
@@ -4049,8 +4311,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 34.44,
-    "lowestPriceWithShipping": 34.98,
+    "marketPrice": 34.04,
+    "lowestPriceWithShipping": 29.99,
     "color": [
       "Yellow"
     ],
@@ -4067,6 +4329,75 @@
     "productId": 515281
   },
   {
+    "productName": "Capone\"Gang\"Bege (CS 2023 Top Players Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Rare"
+    ],
+    "color": [
+      "Yellow"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Ranged"
+    ],
+    "subtypes": [
+      "Firetank Pirates"
+    ],
+    "number": "OP04-100",
+    "productId": 525680
+  },
+  {
+    "productName": "Capone\"Gang\"Bege (CS 2023 Top Players Pack) [Finalist]",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Rare"
+    ],
+    "color": [
+      "Yellow"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Ranged"
+    ],
+    "subtypes": [
+      "Firetank Pirates"
+    ],
+    "number": "OP04-100",
+    "productId": 525681
+  },
+  {
+    "productName": "Capone\"Gang\"Bege (CS 2023 Top Players Pack) [Winner]",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Rare"
+    ],
+    "color": [
+      "Yellow"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Ranged"
+    ],
+    "subtypes": [
+      "Firetank Pirates"
+    ],
+    "number": "OP04-100",
+    "productId": 525682
+  },
+  {
     "productName": "Captain McKinley",
     "setName": [
       "Awakening of the New Era"
@@ -4074,8 +4405,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.08,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
     ],
@@ -4099,8 +4430,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.78,
-    "lowestPriceWithShipping": 3.47,
+    "marketPrice": 3.18,
+    "lowestPriceWithShipping": 2.5,
     "color": [
       "Yellow"
     ],
@@ -4124,7 +4455,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -4150,8 +4481,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.31,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.6,
+    "lowestPriceWithShipping": 0.18,
     "color": [
       "Purple"
     ],
@@ -4176,7 +4507,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
@@ -4226,7 +4557,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.11,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Blue"
@@ -4251,8 +4582,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.19,
-    "lowestPriceWithShipping": 1.72,
+    "marketPrice": 1.34,
+    "lowestPriceWithShipping": 1.69,
     "color": [
       "Blue"
     ],
@@ -4277,7 +4608,7 @@
       "Rare"
     ],
     "marketPrice": 0.23,
-    "lowestPriceWithShipping": 0.04,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Green"
     ],
@@ -4302,7 +4633,7 @@
       "Common"
     ],
     "marketPrice": 0.08,
-    "lowestPriceWithShipping": 0.04,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Red"
     ],
@@ -4321,38 +4652,12 @@
   {
     "productName": "Cavendish",
     "setName": [
-      "Kingdoms of Intrigue"
-    ],
-    "rarityName": [
-      "Rare"
-    ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.01,
-    "color": [
-      "Black"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Slash"
-    ],
-    "subtypes": [
-      "Beautiful Pirates",
-      "Dressrosa"
-    ],
-    "number": "OP04-081",
-    "productId": 516795
-  },
-  {
-    "productName": "Cavendish",
-    "setName": [
       "Romance Dawn"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -4371,6 +4676,32 @@
     "productId": 454520
   },
   {
+    "productName": "Cavendish",
+    "setName": [
+      "Kingdoms of Intrigue"
+    ],
+    "rarityName": [
+      "Rare"
+    ],
+    "marketPrice": 0.09,
+    "lowestPriceWithShipping": 0.02,
+    "color": [
+      "Black"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Beautiful Pirates",
+      "Dressrosa"
+    ],
+    "number": "OP04-081",
+    "productId": 516795
+  },
+  {
     "productName": "Cavendish (Box Topper)",
     "setName": [
       "Romance Dawn"
@@ -4378,8 +4709,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1,
-    "lowestPriceWithShipping": 0.99,
+    "marketPrice": 2.18,
+    "lowestPriceWithShipping": 1.5,
     "color": [
       "Red"
     ],
@@ -4405,8 +4736,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 28.96,
-    "lowestPriceWithShipping": 23.98,
+    "marketPrice": 11.67,
+    "lowestPriceWithShipping": 18.72,
     "color": [
       "Red"
     ],
@@ -4430,7 +4761,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.09,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -4480,8 +4811,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 5,
-    "lowestPriceWithShipping": 3.89,
+    "marketPrice": 3.63,
+    "lowestPriceWithShipping": 1.4,
     "color": [
       "Green"
     ],
@@ -4503,8 +4834,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.08,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
     ],
@@ -4526,8 +4857,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.19,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.15,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Yellow"
     ],
@@ -4576,7 +4907,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.03,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
@@ -4601,7 +4932,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.52,
+    "marketPrice": 0.54,
     "lowestPriceWithShipping": 0.52,
     "color": [
       "Yellow"
@@ -4626,8 +4957,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 10.22,
-    "lowestPriceWithShipping": 10.75,
+    "marketPrice": 6.79,
+    "lowestPriceWithShipping": 7,
     "color": [
       "Yellow"
     ],
@@ -4651,8 +4982,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 42.49,
-    "lowestPriceWithShipping": 58,
+    "marketPrice": 57.29,
+    "lowestPriceWithShipping": 47.51,
     "color": [
       "Yellow"
     ],
@@ -4676,7 +5007,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.03,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
@@ -4701,7 +5032,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.37,
+    "marketPrice": 0.38,
     "lowestPriceWithShipping": 0.23,
     "color": [
       "Yellow"
@@ -4726,8 +5057,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 31.72,
-    "lowestPriceWithShipping": 20,
+    "marketPrice": 23.68,
+    "lowestPriceWithShipping": 34,
     "color": [
       "Yellow"
     ],
@@ -4751,8 +5082,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 8.81,
-    "lowestPriceWithShipping": 5.97,
+    "marketPrice": 6.63,
+    "lowestPriceWithShipping": 6.53,
     "color": [
       "Yellow"
     ],
@@ -4799,8 +5130,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 17.15,
-    "lowestPriceWithShipping": 24.95,
+    "marketPrice": 20.08,
+    "lowestPriceWithShipping": 49.93,
     "color": [
       "Yellow"
     ],
@@ -4824,8 +5155,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 9.4,
-    "lowestPriceWithShipping": 6,
+    "marketPrice": 6.69,
+    "lowestPriceWithShipping": 6.69,
     "color": [
       "Yellow"
     ],
@@ -4872,8 +5203,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 13.13,
-    "lowestPriceWithShipping": 13,
+    "marketPrice": 10.69,
+    "lowestPriceWithShipping": 11.99,
     "color": [
       "Yellow"
     ],
@@ -4897,8 +5228,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 43.44,
-    "lowestPriceWithShipping": 40.4,
+    "marketPrice": 38.58,
+    "lowestPriceWithShipping": 30.97,
     "color": [
       "Yellow"
     ],
@@ -4922,8 +5253,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.27,
-    "lowestPriceWithShipping": 0.18,
+    "marketPrice": 0.26,
+    "lowestPriceWithShipping": 0.15,
     "color": [
       "Yellow"
     ],
@@ -4947,7 +5278,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Yellow"
@@ -4972,8 +5303,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.35,
-    "lowestPriceWithShipping": 1.07,
+    "marketPrice": 1.31,
+    "lowestPriceWithShipping": 0.99,
     "color": [
       "Yellow"
     ],
@@ -4997,7 +5328,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.12,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
@@ -5022,8 +5353,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.83,
-    "lowestPriceWithShipping": 1.25,
+    "marketPrice": 2.35,
+    "lowestPriceWithShipping": 1.5,
     "color": [
       "Yellow"
     ],
@@ -5047,8 +5378,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.18,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.2,
+    "lowestPriceWithShipping": 0.08,
     "color": [
       "Yellow"
     ],
@@ -5072,8 +5403,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 164.74,
-    "lowestPriceWithShipping": 217.99,
+    "marketPrice": 247.54,
+    "lowestPriceWithShipping": 215,
     "color": [
       "Yellow"
     ],
@@ -5095,8 +5426,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 73.36,
-    "lowestPriceWithShipping": 69.9,
+    "marketPrice": 73.88,
+    "lowestPriceWithShipping": 72.89,
     "color": [
       "Yellow"
     ],
@@ -5120,8 +5451,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 120.22,
-    "lowestPriceWithShipping": 115,
+    "marketPrice": 112.88,
+    "lowestPriceWithShipping": 109.99,
     "color": [
       "Yellow"
     ],
@@ -5145,8 +5476,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.3,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.35,
+    "lowestPriceWithShipping": 0.3,
     "color": [
       "Yellow"
     ],
@@ -5171,8 +5502,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 15.88,
-    "lowestPriceWithShipping": 17,
+    "marketPrice": 10.23,
+    "lowestPriceWithShipping": 10.3,
     "color": [
       "Yellow"
     ],
@@ -5197,7 +5528,7 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.14,
+    "marketPrice": 0.13,
     "lowestPriceWithShipping": 0.03,
     "color": [
       "Yellow"
@@ -5223,8 +5554,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 50.37,
-    "lowestPriceWithShipping": 51,
+    "marketPrice": 56.68,
+    "lowestPriceWithShipping": 44.4,
     "color": [
       "Yellow"
     ],
@@ -5246,8 +5577,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 4.02,
-    "lowestPriceWithShipping": 3.97,
+    "marketPrice": 5.05,
+    "lowestPriceWithShipping": 5.8,
     "color": [
       "Yellow"
     ],
@@ -5271,8 +5602,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 28.29,
-    "lowestPriceWithShipping": 27,
+    "marketPrice": 27.82,
+    "lowestPriceWithShipping": 24.9,
     "color": [
       "Yellow"
     ],
@@ -5296,7 +5627,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.11,
+    "marketPrice": 0.13,
     "lowestPriceWithShipping": 0.07,
     "color": [
       "Yellow"
@@ -5321,8 +5652,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.1,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Yellow"
     ],
@@ -5346,8 +5677,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.97,
-    "lowestPriceWithShipping": 3,
+    "marketPrice": 2.04,
+    "lowestPriceWithShipping": 2.19,
     "color": [
       "Yellow"
     ],
@@ -5371,7 +5702,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
@@ -5396,8 +5727,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.95,
-    "lowestPriceWithShipping": 2.68,
+    "marketPrice": 3.01,
+    "lowestPriceWithShipping": 2.28,
     "color": [
       "Yellow"
     ],
@@ -5446,8 +5777,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.91,
-    "lowestPriceWithShipping": 1.91,
+    "marketPrice": 1.99,
+    "lowestPriceWithShipping": 1.9,
     "color": [
       "Yellow"
     ],
@@ -5471,7 +5802,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
@@ -5496,8 +5827,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.63,
-    "lowestPriceWithShipping": 2.99,
+    "marketPrice": 3.35,
+    "lowestPriceWithShipping": 2.96,
     "color": [
       "Yellow"
     ],
@@ -5521,8 +5852,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 4.09,
-    "lowestPriceWithShipping": 3.45,
+    "marketPrice": 4.68,
+    "lowestPriceWithShipping": 4.2,
     "color": [
       "Yellow"
     ],
@@ -5546,8 +5877,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 29.73,
-    "lowestPriceWithShipping": 26,
+    "marketPrice": 34.11,
+    "lowestPriceWithShipping": 35,
     "color": [
       "Yellow"
     ],
@@ -5572,7 +5903,7 @@
       "Common"
     ],
     "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.01,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Yellow"
     ],
@@ -5597,8 +5928,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.68,
-    "lowestPriceWithShipping": 0.68,
+    "marketPrice": 0.67,
+    "lowestPriceWithShipping": 0.67,
     "color": [
       "Yellow"
     ],
@@ -5623,8 +5954,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.21,
-    "lowestPriceWithShipping": 0.12,
+    "marketPrice": 0.17,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Yellow"
     ],
@@ -5648,8 +5979,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.45,
-    "lowestPriceWithShipping": 0.14,
+    "marketPrice": 0.43,
+    "lowestPriceWithShipping": 0.21,
     "color": [
       "Yellow"
     ],
@@ -5673,8 +6004,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 42.17,
-    "lowestPriceWithShipping": 38.5,
+    "marketPrice": 61.29,
+    "lowestPriceWithShipping": 53.94,
     "color": [
       "Yellow"
     ],
@@ -5698,8 +6029,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.95,
-    "lowestPriceWithShipping": 1.9,
+    "marketPrice": 2.78,
+    "lowestPriceWithShipping": 1.79,
     "color": [
       "Yellow"
     ],
@@ -5723,8 +6054,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 92.64,
-    "lowestPriceWithShipping": 46.88,
+    "marketPrice": 48.92,
+    "lowestPriceWithShipping": 44.69,
     "color": [
       "Yellow"
     ],
@@ -5748,8 +6079,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 16.77,
-    "lowestPriceWithShipping": 15,
+    "marketPrice": 22.01,
+    "lowestPriceWithShipping": 40.9,
     "color": [
       "Yellow"
     ],
@@ -5773,7 +6104,7 @@
     "rarityName": [
       "Promo"
     ],
-    "lowestPriceWithShipping": 1000,
+    "marketPrice": 1000,
     "color": [
       "Yellow"
     ],
@@ -5797,8 +6128,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 107.21,
-    "lowestPriceWithShipping": 83,
+    "marketPrice": 98.68,
+    "lowestPriceWithShipping": 75,
     "color": [
       "Yellow"
     ],
@@ -5822,8 +6153,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 18.6,
-    "lowestPriceWithShipping": 19.99,
+    "marketPrice": 21.71,
+    "lowestPriceWithShipping": 23.99,
     "color": [
       "Yellow"
     ],
@@ -5870,8 +6201,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.57,
-    "lowestPriceWithShipping": 0.24,
+    "marketPrice": 0.35,
+    "lowestPriceWithShipping": 0.17,
     "color": [
       "Yellow"
     ],
@@ -5895,8 +6226,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.09,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Yellow"
     ],
@@ -5920,8 +6251,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 3.41,
-    "lowestPriceWithShipping": 3.4,
+    "marketPrice": 3.44,
+    "lowestPriceWithShipping": 2.75,
     "color": [
       "Green"
     ],
@@ -5947,8 +6278,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.11,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Green"
     ],
@@ -5974,8 +6305,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.63,
-    "lowestPriceWithShipping": 0.5,
+    "marketPrice": 0.88,
+    "lowestPriceWithShipping": 1.98,
     "color": [
       "Purple"
     ],
@@ -6001,7 +6332,7 @@
       "Common"
     ],
     "marketPrice": 0.05,
-    "lowestPriceWithShipping": 0.01,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Purple"
     ],
@@ -6026,7 +6357,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.3,
+    "marketPrice": 0.34,
     "lowestPriceWithShipping": 0.14,
     "color": [
       "Black"
@@ -6052,7 +6383,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.04,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -6078,8 +6409,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 9.06,
-    "lowestPriceWithShipping": 6.99,
+    "marketPrice": 7.16,
+    "lowestPriceWithShipping": 5.98,
     "color": [
       "Purple"
     ],
@@ -6104,7 +6435,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -6130,7 +6461,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.11,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -6153,8 +6484,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.11,
-    "lowestPriceWithShipping": 0.07,
+    "marketPrice": 0.14,
+    "lowestPriceWithShipping": 0.08,
     "color": [
       "Yellow"
     ],
@@ -6178,8 +6509,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 16.72,
-    "lowestPriceWithShipping": 16.63,
+    "marketPrice": 15.45,
+    "lowestPriceWithShipping": 17.9,
     "color": [
       "Yellow"
     ],
@@ -6228,8 +6559,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.36,
-    "lowestPriceWithShipping": 1.29,
+    "marketPrice": 1.57,
+    "lowestPriceWithShipping": 1.28,
     "color": [
       "Black"
     ],
@@ -6253,8 +6584,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.68,
-    "lowestPriceWithShipping": 4.19,
+    "marketPrice": 3.26,
+    "lowestPriceWithShipping": 3,
     "color": [
       "Black"
     ],
@@ -6276,7 +6607,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -6299,7 +6630,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
@@ -6323,8 +6654,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 5.71,
-    "lowestPriceWithShipping": 5.8,
+    "marketPrice": 6.22,
+    "lowestPriceWithShipping": 4.99,
     "color": [
       "Blue"
     ],
@@ -6349,7 +6680,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Blue"
@@ -6375,8 +6706,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.4,
-    "lowestPriceWithShipping": 0.2,
+    "marketPrice": 0.88,
+    "lowestPriceWithShipping": 0.7,
     "color": [
       "Blue"
     ],
@@ -6401,8 +6732,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 41.5,
-    "lowestPriceWithShipping": 41,
+    "marketPrice": 68.08,
+    "lowestPriceWithShipping": 59.01,
     "color": [
       "Blue"
     ],
@@ -6427,8 +6758,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 0.52,
-    "lowestPriceWithShipping": 0.2,
+    "marketPrice": 0.49,
+    "lowestPriceWithShipping": 0.25,
     "color": [
       "Blue"
     ],
@@ -6453,8 +6784,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.46,
-    "lowestPriceWithShipping": 1.29,
+    "marketPrice": 3.1,
+    "lowestPriceWithShipping": 2.18,
     "color": [
       "Blue"
     ],
@@ -6479,7 +6810,7 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple",
@@ -6506,8 +6837,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 25,
-    "lowestPriceWithShipping": 25.5,
+    "marketPrice": 39.64,
+    "lowestPriceWithShipping": 38,
     "color": [
       "Purple",
       "Yellow"
@@ -6533,8 +6864,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 0.32,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.78,
+    "lowestPriceWithShipping": 0.34,
     "color": [
       "Purple"
     ],
@@ -6559,8 +6890,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 8.1,
-    "lowestPriceWithShipping": 8.01,
+    "marketPrice": 13.5,
+    "lowestPriceWithShipping": 12.01,
     "color": [
       "Purple"
     ],
@@ -6585,8 +6916,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.2,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.22,
+    "lowestPriceWithShipping": 0.06,
     "color": [
       "Blue",
       "Purple"
@@ -6612,8 +6943,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 96.61,
-    "lowestPriceWithShipping": 96.8,
+    "marketPrice": 167.39,
+    "lowestPriceWithShipping": 135.98,
     "color": [
       "Blue",
       "Purple"
@@ -6639,8 +6970,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.54,
-    "lowestPriceWithShipping": 1.26,
+    "marketPrice": 1.43,
+    "lowestPriceWithShipping": 1,
     "color": [
       "Blue"
     ],
@@ -6665,8 +6996,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 18.4,
-    "lowestPriceWithShipping": 20,
+    "marketPrice": 34.27,
+    "lowestPriceWithShipping": 22.78,
     "color": [
       "Blue"
     ],
@@ -6691,8 +7022,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 37.98,
-    "lowestPriceWithShipping": 27.5,
+    "marketPrice": 40.99,
+    "lowestPriceWithShipping": 71.95,
     "color": [
       "Blue"
     ],
@@ -6717,8 +7048,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 19.65,
-    "lowestPriceWithShipping": 18.9,
+    "marketPrice": 22.28,
+    "lowestPriceWithShipping": 33.99,
     "color": [
       "Blue"
     ],
@@ -6767,8 +7098,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 36.76,
-    "lowestPriceWithShipping": 29.37,
+    "marketPrice": 35.67,
+    "lowestPriceWithShipping": 90,
     "color": [
       "Blue"
     ],
@@ -6793,8 +7124,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 17.85,
-    "lowestPriceWithShipping": 15,
+    "marketPrice": 21.07,
+    "lowestPriceWithShipping": 36.99,
     "color": [
       "Blue"
     ],
@@ -6843,8 +7174,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.39,
-    "lowestPriceWithShipping": 0.99,
+    "marketPrice": 1.43,
+    "lowestPriceWithShipping": 1.17,
     "color": [
       "Blue"
     ],
@@ -6869,8 +7200,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 0.53,
-    "lowestPriceWithShipping": 0.31,
+    "marketPrice": 0.74,
+    "lowestPriceWithShipping": 0.46,
     "color": [
       "Blue"
     ],
@@ -6895,8 +7226,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 4.52,
-    "lowestPriceWithShipping": 3.99,
+    "marketPrice": 5.61,
+    "lowestPriceWithShipping": 5,
     "color": [
       "Blue"
     ],
@@ -6921,8 +7252,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 15.19,
-    "lowestPriceWithShipping": 13,
+    "marketPrice": 14.21,
+    "lowestPriceWithShipping": 7.26,
     "color": [
       "Red"
     ],
@@ -6944,8 +7275,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.11,
-    "lowestPriceWithShipping": 0.06,
+    "marketPrice": 0.14,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Red"
     ],
@@ -6967,7 +7298,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.49,
+    "marketPrice": 0.48,
     "lowestPriceWithShipping": 0.28,
     "color": [
       "Red"
@@ -6992,7 +7323,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -7017,8 +7348,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 8.82,
-    "lowestPriceWithShipping": 6.3,
+    "marketPrice": 7,
+    "lowestPriceWithShipping": 7.01,
     "color": [
       "Red"
     ],
@@ -7042,8 +7373,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.2,
-    "lowestPriceWithShipping": 0.99,
+    "marketPrice": 1.1,
+    "lowestPriceWithShipping": 0.79,
     "color": [
       "Red"
     ],
@@ -7067,8 +7398,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 10.61,
-    "lowestPriceWithShipping": 8.94,
+    "marketPrice": 7.12,
+    "lowestPriceWithShipping": 5.5,
     "color": [
       "Blue"
     ],
@@ -7091,8 +7422,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.06,
+    "marketPrice": 0.19,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Blue"
     ],
@@ -7110,31 +7441,12 @@
   {
     "productName": "DON!! Card",
     "setName": [
-      "Super Pre Release Starter Deck 1 Straw Hat Crew"
-    ],
-    "rarityName": [
-      "DON!!"
-    ],
-    "marketPrice": 0.69,
-    "lowestPriceWithShipping": 0.69,
-    "color": null,
-    "cardType": [
-      "DON!!"
-    ],
-    "attribute": null,
-    "subtypes": null,
-    "number": null,
-    "productId": 434340
-  },
-  {
-    "productName": "DON!! Card",
-    "setName": [
       "Romance Dawn"
     ],
     "rarityName": [
       "DON!!"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": null,
     "cardType": [
@@ -7148,13 +7460,32 @@
   {
     "productName": "DON!! Card",
     "setName": [
+      "Super Pre Release Starter Deck 1 Straw Hat Crew"
+    ],
+    "rarityName": [
+      "DON!!"
+    ],
+    "marketPrice": 0.89,
+    "lowestPriceWithShipping": 0.5,
+    "color": null,
+    "cardType": [
+      "DON!!"
+    ],
+    "attribute": null,
+    "subtypes": null,
+    "number": null,
+    "productId": 434340
+  },
+  {
+    "productName": "DON!! Card",
+    "setName": [
       "Ultra Deck The Three Captains"
     ],
     "rarityName": [
       "DON!!"
     ],
-    "marketPrice": 0.34,
-    "lowestPriceWithShipping": 0.22,
+    "marketPrice": 0.41,
+    "lowestPriceWithShipping": 0.29,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7172,8 +7503,8 @@
     "rarityName": [
       "DON!!"
     ],
-    "marketPrice": 3.64,
-    "lowestPriceWithShipping": 3.49,
+    "marketPrice": 3.28,
+    "lowestPriceWithShipping": 2.72,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7191,8 +7522,8 @@
     "rarityName": [
       "DON!!"
     ],
-    "marketPrice": 0.9,
-    "lowestPriceWithShipping": 0.69,
+    "marketPrice": 0.94,
+    "lowestPriceWithShipping": 0.7,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7210,8 +7541,8 @@
     "rarityName": [
       "DON!!"
     ],
-    "marketPrice": 0.38,
-    "lowestPriceWithShipping": 0.17,
+    "marketPrice": 0.32,
+    "lowestPriceWithShipping": 0.12,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7229,7 +7560,7 @@
     "rarityName": [
       "DON!!"
     ],
-    "marketPrice": 0.59,
+    "marketPrice": 0.57,
     "lowestPriceWithShipping": 0.2,
     "color": null,
     "cardType": [
@@ -7248,8 +7579,8 @@
     "rarityName": [
       "DON!!"
     ],
-    "marketPrice": 3.09,
-    "lowestPriceWithShipping": 2.69,
+    "marketPrice": 2.69,
+    "lowestPriceWithShipping": 2.1,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7267,8 +7598,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 49.93,
-    "lowestPriceWithShipping": 60,
+    "marketPrice": 51.41,
+    "lowestPriceWithShipping": 45.99,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7286,8 +7617,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 38.76,
-    "lowestPriceWithShipping": 35,
+    "marketPrice": 47.57,
+    "lowestPriceWithShipping": 65.8,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7298,6 +7629,25 @@
     "productId": 483171
   },
   {
+    "productName": "DON!! Card (CS 2023 Celebration Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "DON!!"
+    ],
+    "marketPrice": 71.38,
+    "lowestPriceWithShipping": 54,
+    "color": null,
+    "cardType": [
+      "DON!!"
+    ],
+    "attribute": null,
+    "subtypes": null,
+    "number": null,
+    "productId": 525340
+  },
+  {
     "productName": "DON!! Card (Color) (Special DON!! Card Pack)",
     "setName": [
       "Kingdoms of Intrigue"
@@ -7305,8 +7655,8 @@
     "rarityName": [
       "DON!!"
     ],
-    "marketPrice": 5.41,
-    "lowestPriceWithShipping": 5.9,
+    "marketPrice": 4.75,
+    "lowestPriceWithShipping": 4.75,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7324,8 +7674,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 8.57,
-    "lowestPriceWithShipping": 8.34,
+    "marketPrice": 11.58,
+    "lowestPriceWithShipping": 11.4,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7343,8 +7693,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 71.45,
-    "lowestPriceWithShipping": 72,
+    "marketPrice": 67.1,
+    "lowestPriceWithShipping": 61.99,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7362,8 +7712,8 @@
     "rarityName": [
       "DON!!"
     ],
-    "marketPrice": 10.01,
-    "lowestPriceWithShipping": 9.5,
+    "marketPrice": 7.69,
+    "lowestPriceWithShipping": 7.97,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7381,7 +7731,7 @@
     "rarityName": [
       "DON!!"
     ],
-    "marketPrice": 2.14,
+    "marketPrice": 1.96,
     "lowestPriceWithShipping": 1.74,
     "color": null,
     "cardType": [
@@ -7400,8 +7750,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 14.63,
-    "lowestPriceWithShipping": 16.95,
+    "marketPrice": 12.03,
+    "lowestPriceWithShipping": 11.39,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7419,8 +7769,8 @@
     "rarityName": [
       "DON!!"
     ],
-    "marketPrice": 2.41,
-    "lowestPriceWithShipping": 1.99,
+    "marketPrice": 2.46,
+    "lowestPriceWithShipping": 2.3,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7438,8 +7788,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 71.8,
-    "lowestPriceWithShipping": 77,
+    "marketPrice": 66.59,
+    "lowestPriceWithShipping": 63.97,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7457,8 +7807,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 72.66,
-    "lowestPriceWithShipping": 68.97,
+    "marketPrice": 63,
+    "lowestPriceWithShipping": 89.99,
     "number": null,
     "productId": 493339
   },
@@ -7470,8 +7820,7 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 77.66,
-    "lowestPriceWithShipping": 90,
+    "marketPrice": 82.89,
     "number": null,
     "productId": 483165
   },
@@ -7483,8 +7832,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 67.71,
-    "lowestPriceWithShipping": 93.98,
+    "marketPrice": 84.88,
+    "lowestPriceWithShipping": 84.9,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7502,8 +7851,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 81.19,
-    "lowestPriceWithShipping": 81.5,
+    "marketPrice": 87.88,
+    "lowestPriceWithShipping": 84.9,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7521,8 +7870,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 71.91,
-    "lowestPriceWithShipping": 70,
+    "marketPrice": 71.34,
+    "lowestPriceWithShipping": 74.99,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7540,8 +7889,8 @@
     "rarityName": [
       "DON!!"
     ],
-    "marketPrice": 1.93,
-    "lowestPriceWithShipping": 1.5,
+    "marketPrice": 2.17,
+    "lowestPriceWithShipping": 1.99,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7559,8 +7908,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 53.45,
-    "lowestPriceWithShipping": 52.99,
+    "marketPrice": 59.12,
+    "lowestPriceWithShipping": 63,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7578,8 +7927,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 41.8,
-    "lowestPriceWithShipping": 49,
+    "marketPrice": 51.07,
+    "lowestPriceWithShipping": 63.99,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7597,8 +7946,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 2.68,
-    "lowestPriceWithShipping": 2.45,
+    "marketPrice": 3.17,
+    "lowestPriceWithShipping": 2.89,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7616,8 +7965,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 7.14,
-    "lowestPriceWithShipping": 6.53,
+    "marketPrice": 11.04,
+    "lowestPriceWithShipping": 8.69,
     "color": [
       "Red"
     ],
@@ -7639,8 +7988,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 38.78,
-    "lowestPriceWithShipping": 39,
+    "marketPrice": 33.45,
+    "lowestPriceWithShipping": 31.99,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7658,8 +8007,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 39.15,
-    "lowestPriceWithShipping": 47,
+    "marketPrice": 44.61,
+    "lowestPriceWithShipping": 43.94,
     "color": [
       "Green"
     ],
@@ -7682,8 +8031,8 @@
     "rarityName": [
       "DON!!"
     ],
-    "marketPrice": 9.76,
-    "lowestPriceWithShipping": 10,
+    "marketPrice": 9.23,
+    "lowestPriceWithShipping": 9.97,
     "color": null,
     "cardType": [
       "DON!!"
@@ -7701,7 +8050,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -7727,8 +8076,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.73,
-    "lowestPriceWithShipping": 0.57,
+    "marketPrice": 0.68,
+    "lowestPriceWithShipping": 0.56,
     "color": [
       "Green"
     ],
@@ -7744,31 +8093,6 @@
     ],
     "number": "OP04-027",
     "productId": 516850
-  },
-  {
-    "productName": "Daifugo",
-    "setName": [
-      "Paramount War Pre Release Cards"
-    ],
-    "rarityName": [
-      "Uncommon"
-    ],
-    "marketPrice": 0.39,
-    "lowestPriceWithShipping": 0.25,
-    "color": [
-      "Purple"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Ranged"
-    ],
-    "subtypes": [
-      "Animal Kingdom Pirates"
-    ],
-    "number": "OP02-078",
-    "productId": 486718
   },
   {
     "productName": "Daifugo",
@@ -7797,6 +8121,31 @@
     "productId": 486433
   },
   {
+    "productName": "Daifugo",
+    "setName": [
+      "Paramount War Pre Release Cards"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "marketPrice": 0.39,
+    "lowestPriceWithShipping": 0.25,
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Ranged"
+    ],
+    "subtypes": [
+      "Animal Kingdom Pirates"
+    ],
+    "number": "OP02-078",
+    "productId": 486718
+  },
+  {
     "productName": "Dalmatian",
     "setName": [
       "Awakening of the New Era 1st Anniversary Tournament Cards"
@@ -7804,8 +8153,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 15.24,
-    "lowestPriceWithShipping": 15.24,
+    "marketPrice": 4.12,
+    "lowestPriceWithShipping": 2.05,
     "color": [
       "Blue"
     ],
@@ -7829,8 +8178,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.05,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
     ],
@@ -7855,7 +8204,7 @@
       "Rare"
     ],
     "marketPrice": 0.11,
-    "lowestPriceWithShipping": 0.04,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Green"
     ],
@@ -7875,7 +8224,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -7900,8 +8249,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.63,
-    "lowestPriceWithShipping": 0.49,
+    "marketPrice": 0.61,
+    "lowestPriceWithShipping": 0.45,
     "color": [
       "Green"
     ],
@@ -7925,7 +8274,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.12,
+    "marketPrice": 0.1,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Green"
@@ -7949,8 +8298,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.73,
-    "lowestPriceWithShipping": 0.25,
+    "marketPrice": 0.78,
+    "lowestPriceWithShipping": 0.64,
     "color": [
       "Green"
     ],
@@ -7975,8 +8324,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.84,
-    "lowestPriceWithShipping": 0.4,
+    "marketPrice": 1.06,
+    "lowestPriceWithShipping": 0.65,
     "color": [
       "Blue"
     ],
@@ -7999,8 +8348,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 39.13,
-    "lowestPriceWithShipping": 25,
+    "marketPrice": 50.42,
+    "lowestPriceWithShipping": 55.9,
     "number": null,
     "productId": 516299
   },
@@ -8024,8 +8373,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.78,
-    "lowestPriceWithShipping": 6,
+    "marketPrice": 4.62,
+    "lowestPriceWithShipping": 3.48,
     "color": [
       "Red"
     ],
@@ -8047,8 +8396,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.77,
-    "lowestPriceWithShipping": 3.25,
+    "marketPrice": 3.72,
+    "lowestPriceWithShipping": 3.35,
     "color": [
       "Red"
     ],
@@ -8070,7 +8419,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 2.62,
+    "marketPrice": 1.72,
     "lowestPriceWithShipping": 0.95,
     "color": [
       "Yellow"
@@ -8093,7 +8442,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Yellow"
@@ -8116,8 +8465,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.13,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Green"
     ],
@@ -8140,8 +8489,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.24,
-    "lowestPriceWithShipping": 1.99,
+    "marketPrice": 1.81,
+    "lowestPriceWithShipping": 3.75,
     "color": [
       "Green"
     ],
@@ -8164,7 +8513,7 @@
       "Rare"
     ],
     "marketPrice": 0.12,
-    "lowestPriceWithShipping": 0.03,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Green"
     ],
@@ -8188,8 +8537,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 7.98,
-    "lowestPriceWithShipping": 8.75,
+    "marketPrice": 8.26,
+    "lowestPriceWithShipping": 8,
     "color": [
       "Green"
     ],
@@ -8213,7 +8562,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.03,
+    "marketPrice": 0.04,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -8238,8 +8587,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.88,
-    "lowestPriceWithShipping": 0.72,
+    "marketPrice": 0.87,
+    "lowestPriceWithShipping": 0.69,
     "color": [
       "Black"
     ],
@@ -8263,8 +8612,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.69,
-    "lowestPriceWithShipping": 0.45,
+    "marketPrice": 0.72,
+    "lowestPriceWithShipping": 0.44,
     "color": [
       "Purple"
     ],
@@ -8288,7 +8637,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -8314,8 +8663,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.93,
-    "lowestPriceWithShipping": 1,
+    "marketPrice": 3.07,
+    "lowestPriceWithShipping": 17.65,
     "color": [
       "Red"
     ],
@@ -8359,6 +8708,31 @@
   {
     "productName": "Domino",
     "setName": [
+      "Paramount War Pre Release Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 8.58,
+    "lowestPriceWithShipping": 30,
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Wisdom"
+    ],
+    "subtypes": [
+      "Impel Down"
+    ],
+    "number": "OP02-081",
+    "productId": 486642
+  },
+  {
+    "productName": "Domino",
+    "setName": [
       "Paramount War"
     ],
     "rarityName": [
@@ -8382,31 +8756,6 @@
     "productId": 486441
   },
   {
-    "productName": "Domino",
-    "setName": [
-      "Paramount War Pre Release Cards"
-    ],
-    "rarityName": [
-      "Common"
-    ],
-    "marketPrice": 6.32,
-    "lowestPriceWithShipping": 7.97,
-    "color": [
-      "Purple"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Wisdom"
-    ],
-    "subtypes": [
-      "Impel Down"
-    ],
-    "number": "OP02-081",
-    "productId": 486642
-  },
-  {
     "productName": "Donquixote Doflamingo",
     "setName": [
       "Starter Deck 3 The Seven Warlords of The Sea"
@@ -8414,8 +8763,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.74,
-    "lowestPriceWithShipping": 2.8,
+    "marketPrice": 2.16,
+    "lowestPriceWithShipping": 1.9,
     "color": [
       "Blue"
     ],
@@ -8440,8 +8789,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.96,
-    "lowestPriceWithShipping": 1.83,
+    "marketPrice": 1.94,
+    "lowestPriceWithShipping": 1.84,
     "color": [
       "Blue"
     ],
@@ -8466,8 +8815,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 5.36,
-    "lowestPriceWithShipping": 7.9,
+    "marketPrice": 6.99,
+    "lowestPriceWithShipping": 5,
     "color": [
       "Blue"
     ],
@@ -8492,7 +8841,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.13,
+    "marketPrice": 0.15,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Blue"
@@ -8518,7 +8867,7 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green",
@@ -8545,8 +8894,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 52.32,
-    "lowestPriceWithShipping": 52,
+    "marketPrice": 58.9,
+    "lowestPriceWithShipping": 51.99,
     "color": [
       "Green",
       "Purple"
@@ -8572,8 +8921,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.06,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
     ],
@@ -8597,8 +8946,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 6.23,
-    "lowestPriceWithShipping": 5.73,
+    "marketPrice": 4.56,
+    "lowestPriceWithShipping": 4,
     "color": [
       "Green"
     ],
@@ -8622,8 +8971,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 29.01,
-    "lowestPriceWithShipping": 26,
+    "marketPrice": 20.6,
+    "lowestPriceWithShipping": 16,
     "color": [
       "Green"
     ],
@@ -8647,7 +8996,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.1,
     "lowestPriceWithShipping": 0.04,
     "color": [
       "Green"
@@ -8672,8 +9021,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 3.33,
-    "lowestPriceWithShipping": 2.99,
+    "marketPrice": 6.4,
+    "lowestPriceWithShipping": 5,
     "color": [
       "Green"
     ],
@@ -8698,8 +9047,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 32.14,
-    "lowestPriceWithShipping": 39.95,
+    "marketPrice": 42.22,
+    "lowestPriceWithShipping": 44.8,
     "color": [
       "Green"
     ],
@@ -8724,8 +9073,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.28,
-    "lowestPriceWithShipping": 0.19,
+    "marketPrice": 0.26,
+    "lowestPriceWithShipping": 0.13,
     "color": [
       "Blue"
     ],
@@ -8750,8 +9099,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 188.03,
-    "lowestPriceWithShipping": 180,
+    "marketPrice": 266.44,
+    "lowestPriceWithShipping": 243.99,
     "color": [
       "Blue"
     ],
@@ -8776,8 +9125,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 3.27,
-    "lowestPriceWithShipping": 3.25,
+    "marketPrice": 2.99,
+    "lowestPriceWithShipping": 2.5,
     "color": [
       "Blue"
     ],
@@ -8802,8 +9151,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 65.23,
-    "lowestPriceWithShipping": 60,
+    "marketPrice": 80.36,
+    "lowestPriceWithShipping": 65,
     "color": [
       "Blue"
     ],
@@ -8828,8 +9177,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 4.28,
-    "lowestPriceWithShipping": 4,
+    "marketPrice": 7.06,
+    "lowestPriceWithShipping": 4.87,
     "color": [
       "Blue"
     ],
@@ -8854,8 +9203,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 39.07,
-    "lowestPriceWithShipping": 38.98,
+    "marketPrice": 60.61,
+    "lowestPriceWithShipping": 48.99,
     "color": [
       "Blue"
     ],
@@ -8880,7 +9229,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.97,
+    "marketPrice": 0.94,
     "lowestPriceWithShipping": 0.79,
     "color": [
       "Green"
@@ -8926,7 +9275,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.11,
+    "marketPrice": 0.09,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Black"
@@ -8952,8 +9301,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.41,
-    "lowestPriceWithShipping": 0.75,
+    "marketPrice": 1.39,
+    "lowestPriceWithShipping": 1.04,
     "color": [
       "Black"
     ],
@@ -8978,8 +9327,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 3.52,
-    "lowestPriceWithShipping": 3.2,
+    "marketPrice": 5.5,
+    "lowestPriceWithShipping": 4.8,
     "color": [
       "Green"
     ],
@@ -9004,8 +9353,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.12,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.11,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Blue",
       "Green"
@@ -9031,8 +9380,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 36.56,
-    "lowestPriceWithShipping": 35.25,
+    "marketPrice": 38.6,
+    "lowestPriceWithShipping": 39.82,
     "color": [
       "Blue",
       "Green"
@@ -9058,8 +9407,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.21,
-    "lowestPriceWithShipping": 0.09,
+    "marketPrice": 0.71,
+    "lowestPriceWithShipping": 0.4,
     "color": [
       "Green"
     ],
@@ -9084,8 +9433,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 13.38,
-    "lowestPriceWithShipping": 13.14,
+    "marketPrice": 19.66,
+    "lowestPriceWithShipping": 19.66,
     "color": [
       "Green"
     ],
@@ -9110,8 +9459,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 9.72,
-    "lowestPriceWithShipping": 9,
+    "marketPrice": 5.02,
+    "lowestPriceWithShipping": 5,
     "color": [
       "Black"
     ],
@@ -9136,8 +9485,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.54,
-    "lowestPriceWithShipping": 1.4,
+    "marketPrice": 1.01,
+    "lowestPriceWithShipping": 0.7,
     "color": [
       "Black"
     ],
@@ -9162,8 +9511,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 12.57,
-    "lowestPriceWithShipping": 11.24,
+    "marketPrice": 10.92,
+    "lowestPriceWithShipping": 9.95,
     "color": [
       "Black"
     ],
@@ -9188,8 +9537,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 13.85,
-    "lowestPriceWithShipping": 17.97,
+    "marketPrice": 18.44,
+    "lowestPriceWithShipping": 21,
     "number": null,
     "productId": 493752
   },
@@ -9201,8 +9550,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 80.66,
-    "lowestPriceWithShipping": 116.92,
+    "marketPrice": 131.37,
+    "lowestPriceWithShipping": 138.8,
     "number": null,
     "productId": 514029
   },
@@ -9214,8 +9563,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 18.54,
-    "lowestPriceWithShipping": 20.5,
+    "marketPrice": 35.08,
+    "lowestPriceWithShipping": 35.95,
     "number": null,
     "productId": 527060
   },
@@ -9227,8 +9576,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 158.19,
-    "lowestPriceWithShipping": 158.99,
+    "marketPrice": 259.66,
+    "lowestPriceWithShipping": 285,
     "number": null,
     "productId": 527062
   },
@@ -9240,7 +9589,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 886.28,
+    "marketPrice": 1000.48,
+    "lowestPriceWithShipping": 1999.9,
     "number": null,
     "productId": 527063
   },
@@ -9252,8 +9602,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.79,
-    "lowestPriceWithShipping": 0.74,
+    "marketPrice": 0.94,
+    "lowestPriceWithShipping": 1,
     "color": [
       "Purple"
     ],
@@ -9278,8 +9628,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.11,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Purple"
     ],
@@ -9304,8 +9654,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.77,
-    "lowestPriceWithShipping": 1.3,
+    "marketPrice": 2.2,
+    "lowestPriceWithShipping": 2.19,
     "color": [
       "Purple"
     ],
@@ -9330,7 +9680,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -9357,8 +9707,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 4.24,
-    "lowestPriceWithShipping": 2.99,
+    "marketPrice": 3.52,
+    "lowestPriceWithShipping": 3,
     "color": [
       "Blue"
     ],
@@ -9377,37 +9727,12 @@
   {
     "productName": "Dracule Mihawk",
     "setName": [
-      "Starter Deck 3 The Seven Warlords of The Sea"
-    ],
-    "rarityName": [
-      "Common"
-    ],
-    "marketPrice": 1.62,
-    "lowestPriceWithShipping": 1.4,
-    "color": [
-      "Blue"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Slash"
-    ],
-    "subtypes": [
-      "The Seven Warlords of the Sea"
-    ],
-    "number": "ST03-005",
-    "productId": 288272
-  },
-  {
-    "productName": "Dracule Mihawk",
-    "setName": [
       "Paramount War"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.12,
+    "marketPrice": 0.09,
     "lowestPriceWithShipping": 0.03,
     "color": [
       "Blue"
@@ -9427,13 +9752,38 @@
   {
     "productName": "Dracule Mihawk",
     "setName": [
+      "Starter Deck 3 The Seven Warlords of The Sea"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 2.67,
+    "lowestPriceWithShipping": 2.46,
+    "color": [
+      "Blue"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "The Seven Warlords of the Sea"
+    ],
+    "number": "ST03-005",
+    "productId": 288272
+  },
+  {
+    "productName": "Dracule Mihawk",
+    "setName": [
       "Romance Dawn"
     ],
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 16.37,
-    "lowestPriceWithShipping": 16,
+    "marketPrice": 13.74,
+    "lowestPriceWithShipping": 13.05,
     "color": [
       "Blue"
     ],
@@ -9457,8 +9807,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.05,
-    "lowestPriceWithShipping": 2.98,
+    "marketPrice": 3.43,
+    "lowestPriceWithShipping": 3.95,
     "color": [
       "Blue"
     ],
@@ -9475,6 +9825,31 @@
     "productId": 422377
   },
   {
+    "productName": "Dracule Mihawk (CS 2023 Celebration Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 32.03,
+    "lowestPriceWithShipping": 27,
+    "color": [
+      "Blue"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "The Seven Warlords of the Sea"
+    ],
+    "number": "ST03-005",
+    "productId": 525327
+  },
+  {
     "productName": "Dracule Mihawk (Parallel)",
     "setName": [
       "Romance Dawn"
@@ -9482,8 +9857,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 80.8,
-    "lowestPriceWithShipping": 75,
+    "marketPrice": 130.38,
+    "lowestPriceWithShipping": 113.5,
     "color": [
       "Blue"
     ],
@@ -9507,8 +9882,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 6.03,
-    "lowestPriceWithShipping": 6,
+    "marketPrice": 10.62,
+    "lowestPriceWithShipping": 11.25,
     "color": [
       "Blue"
     ],
@@ -9532,8 +9907,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.81,
-    "lowestPriceWithShipping": 0.5,
+    "marketPrice": 1.74,
+    "lowestPriceWithShipping": 1.24,
     "color": [
       "Blue"
     ],
@@ -9557,8 +9932,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 14.58,
-    "lowestPriceWithShipping": 13.98,
+    "marketPrice": 24.07,
+    "lowestPriceWithShipping": 18.5,
     "color": [
       "Blue"
     ],
@@ -9583,7 +9958,7 @@
       "Common"
     ],
     "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.04,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
     ],
@@ -9606,8 +9981,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 6.75,
-    "lowestPriceWithShipping": 4.01,
+    "marketPrice": 3.36,
+    "lowestPriceWithShipping": 2.5,
     "color": [
       "Black"
     ],
@@ -9621,6 +9996,30 @@
     ],
     "number": "OP05-095",
     "productId": 530948
+  },
+  {
+    "productName": "Dragon Twister Demolition Breath",
+    "setName": [
+      "Kingdoms of Intrigue Pre Release Cards"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "marketPrice": 5.85,
+    "lowestPriceWithShipping": 5.3,
+    "color": [
+      "Blue"
+    ],
+    "cardType": [
+      "Event"
+    ],
+    "attribute": null,
+    "subtypes": [
+      "Animal Kingdom Pirates",
+      "The Four Emperors"
+    ],
+    "number": "OP04-057",
+    "productId": 516869
   },
   {
     "productName": "Dragon Twister Demolition Breath",
@@ -9645,30 +10044,6 @@
     ],
     "number": "OP04-057",
     "productId": 516773
-  },
-  {
-    "productName": "Dragon Twister Demolition Breath",
-    "setName": [
-      "Kingdoms of Intrigue Pre Release Cards"
-    ],
-    "rarityName": [
-      "Uncommon"
-    ],
-    "marketPrice": 6.15,
-    "lowestPriceWithShipping": 4.77,
-    "color": [
-      "Blue"
-    ],
-    "cardType": [
-      "Event"
-    ],
-    "attribute": null,
-    "subtypes": [
-      "Animal Kingdom Pirates",
-      "The Four Emperors"
-    ],
-    "number": "OP04-057",
-    "productId": 516869
   },
   {
     "productName": "Edward Weevil",
@@ -9703,8 +10078,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.37,
-    "lowestPriceWithShipping": 0.2,
+    "marketPrice": 0.32,
+    "lowestPriceWithShipping": 0.15,
     "color": [
       "Blue"
     ],
@@ -9728,8 +10103,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.3,
-    "lowestPriceWithShipping": 0.15,
+    "marketPrice": 0.27,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Red"
     ],
@@ -9754,8 +10129,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 168.82,
-    "lowestPriceWithShipping": 155.98,
+    "marketPrice": 166.72,
+    "lowestPriceWithShipping": 151.99,
     "color": [
       "Red"
     ],
@@ -9780,8 +10155,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 19.73,
-    "lowestPriceWithShipping": 18.44,
+    "marketPrice": 16.68,
+    "lowestPriceWithShipping": 15.99,
     "color": [
       "Red"
     ],
@@ -9806,8 +10181,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 66.25,
-    "lowestPriceWithShipping": 57,
+    "marketPrice": 56.93,
+    "lowestPriceWithShipping": 47.98,
     "color": [
       "Red"
     ],
@@ -9825,6 +10200,32 @@
     "productId": 485861
   },
   {
+    "productName": "Edward.Newgate (Championship 2023)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 1927.7,
+    "lowestPriceWithShipping": 8000,
+    "color": [
+      "Red"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Special"
+    ],
+    "subtypes": [
+      "The Four Emperors",
+      "Whitebeard Pirates"
+    ],
+    "number": "OP02-004",
+    "productId": 514045
+  },
+  {
     "productName": "Edward.Newgate (SP)",
     "setName": [
       "Kingdoms of Intrigue"
@@ -9832,8 +10233,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 51.93,
-    "lowestPriceWithShipping": 54,
+    "marketPrice": 57.12,
+    "lowestPriceWithShipping": 51.98,
     "color": [
       "Red"
     ],
@@ -9858,8 +10259,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.2,
-    "lowestPriceWithShipping": 0.14,
+    "marketPrice": 0.25,
+    "lowestPriceWithShipping": 0.15,
     "color": [
       "Yellow"
     ],
@@ -9881,8 +10282,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 22.78,
-    "lowestPriceWithShipping": 19,
+    "marketPrice": 19.51,
+    "lowestPriceWithShipping": 20.95,
     "color": [
       "Yellow"
     ],
@@ -9904,7 +10305,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -9928,8 +10329,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 7.07,
-    "lowestPriceWithShipping": 6.18,
+    "marketPrice": 6.54,
+    "lowestPriceWithShipping": 15,
     "color": [
       "Black"
     ],
@@ -9954,8 +10355,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.14,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.11,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
     ],
@@ -9980,8 +10381,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.08,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
     ],
@@ -10003,8 +10404,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 42.6,
-    "lowestPriceWithShipping": 17.69,
+    "marketPrice": 3.79,
+    "lowestPriceWithShipping": 4.5,
     "color": [
       "Red"
     ],
@@ -10026,8 +10427,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.19,
-    "lowestPriceWithShipping": 0.14,
+    "marketPrice": 0.23,
+    "lowestPriceWithShipping": 0.12,
     "color": [
       "Red"
     ],
@@ -10051,8 +10452,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 34,
-    "lowestPriceWithShipping": 24,
+    "marketPrice": 22.2,
+    "lowestPriceWithShipping": 22.18,
     "color": [
       "Red"
     ],
@@ -10076,7 +10477,7 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.16,
+    "marketPrice": 0.17,
     "lowestPriceWithShipping": 0.1,
     "color": [
       "Blue"
@@ -10102,8 +10503,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 47.4,
-    "lowestPriceWithShipping": 48.88,
+    "marketPrice": 74.61,
+    "lowestPriceWithShipping": 63.99,
     "color": [
       "Blue"
     ],
@@ -10128,8 +10529,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.09,
-    "lowestPriceWithShipping": 0.99,
+    "marketPrice": 1.73,
+    "lowestPriceWithShipping": 1.59,
     "color": [
       "Blue"
     ],
@@ -10154,8 +10555,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 16.8,
-    "lowestPriceWithShipping": 21.74,
+    "marketPrice": 22.44,
+    "lowestPriceWithShipping": 19.95,
     "color": [
       "Blue"
     ],
@@ -10180,7 +10581,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -10203,7 +10604,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 2.67,
+    "marketPrice": 2.38,
     "lowestPriceWithShipping": 1.9,
     "color": [
       "Red"
@@ -10226,8 +10627,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.15,
-    "lowestPriceWithShipping": 0.07,
+    "marketPrice": 0.23,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Yellow"
     ],
@@ -10251,8 +10652,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 83.55,
-    "lowestPriceWithShipping": 80,
+    "marketPrice": 103.89,
+    "lowestPriceWithShipping": 98,
     "color": [
       "Yellow"
     ],
@@ -10276,8 +10677,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.76,
-    "lowestPriceWithShipping": 0.2,
+    "marketPrice": 2.77,
+    "lowestPriceWithShipping": 2.25,
     "color": [
       "Yellow"
     ],
@@ -10301,8 +10702,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 23,
-    "lowestPriceWithShipping": 19.99,
+    "marketPrice": 26.81,
+    "lowestPriceWithShipping": 24.87,
     "color": [
       "Yellow"
     ],
@@ -10326,8 +10727,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 92.74,
-    "lowestPriceWithShipping": 88.9,
+    "marketPrice": 124.4,
+    "lowestPriceWithShipping": 120.7,
     "color": [
       "Yellow"
     ],
@@ -10351,8 +10752,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.25,
-    "lowestPriceWithShipping": 2.02,
+    "marketPrice": 1.5,
+    "lowestPriceWithShipping": 1.15,
     "color": [
       "Black"
     ],
@@ -10374,8 +10775,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.08,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Black"
     ],
@@ -10422,8 +10823,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.7,
-    "lowestPriceWithShipping": 0.5,
+    "marketPrice": 0.71,
+    "lowestPriceWithShipping": 0.7,
     "color": [
       "Green"
     ],
@@ -10447,8 +10848,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 9.27,
-    "lowestPriceWithShipping": 5.95,
+    "marketPrice": 30.68,
+    "lowestPriceWithShipping": 35,
     "color": [
       "Green"
     ],
@@ -10473,8 +10874,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 6.9,
-    "lowestPriceWithShipping": 6.48,
+    "marketPrice": 5.31,
+    "lowestPriceWithShipping": 5.47,
     "color": [
       "Purple"
     ],
@@ -10498,8 +10899,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 6.36,
-    "lowestPriceWithShipping": 8.25,
+    "marketPrice": 6.74,
+    "lowestPriceWithShipping": 6.99,
     "color": [
       "Green"
     ],
@@ -10524,8 +10925,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 49.55,
-    "lowestPriceWithShipping": 52.77,
+    "marketPrice": 75.08,
+    "lowestPriceWithShipping": 64.94,
     "color": [
       "Green"
     ],
@@ -10550,7 +10951,7 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.37,
+    "marketPrice": 0.44,
     "lowestPriceWithShipping": 0.19,
     "color": [
       "Purple",
@@ -10576,8 +10977,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 7.58,
-    "lowestPriceWithShipping": 4.99,
+    "marketPrice": 7.9,
+    "lowestPriceWithShipping": 4.75,
     "color": [
       "Green"
     ],
@@ -10602,8 +11003,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 2.23,
-    "lowestPriceWithShipping": 1.63,
+    "marketPrice": 2.6,
+    "lowestPriceWithShipping": 2.47,
     "color": [
       "Green"
     ],
@@ -10628,8 +11029,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 3.48,
-    "lowestPriceWithShipping": 2.99,
+    "marketPrice": 2.7,
+    "lowestPriceWithShipping": 3,
     "color": [
       "Purple"
     ],
@@ -10653,8 +11054,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 35.79,
-    "lowestPriceWithShipping": 32.97,
+    "marketPrice": 35.5468,
+    "lowestPriceWithShipping": 36.23,
     "color": [
       "Purple"
     ],
@@ -10678,8 +11079,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 659.01,
-    "lowestPriceWithShipping": 830,
+    "marketPrice": 861.95,
+    "lowestPriceWithShipping": 900,
     "color": [
       "Purple"
     ],
@@ -10696,6 +11097,77 @@
     "productId": 527020
   },
   {
+    "productName": "Eustass\"Captain\"Kid (CS 2023 Top Players Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Super Rare"
+    ],
+    "lowestPriceWithShipping": 3000,
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Special"
+    ],
+    "subtypes": [
+      "Kid Pirates"
+    ],
+    "number": "ST10-013",
+    "productId": 525689
+  },
+  {
+    "productName": "Eustass\"Captain\"Kid (CS 2023 Top Players Pack) [Finalist]",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Super Rare"
+    ],
+    "lowestPriceWithShipping": 5000,
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Special"
+    ],
+    "subtypes": [
+      "Kid Pirates"
+    ],
+    "number": "ST10-013",
+    "productId": 525690
+  },
+  {
+    "productName": "Eustass\"Captain\"Kid (CS 2023 Top Players Pack) [Winner]",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Super Rare"
+    ],
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Special"
+    ],
+    "subtypes": [
+      "Kid Pirates"
+    ],
+    "number": "ST10-013",
+    "productId": 525691
+  },
+  {
     "productName": "Eustass\"Captain\"Kid (Parallel)",
     "setName": [
       "Romance Dawn"
@@ -10703,8 +11175,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 33.6,
-    "lowestPriceWithShipping": 35,
+    "marketPrice": 66.85,
+    "lowestPriceWithShipping": 74.96,
     "color": [
       "Green"
     ],
@@ -10729,8 +11201,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 6.11,
-    "lowestPriceWithShipping": 6.22,
+    "marketPrice": 7.26,
+    "lowestPriceWithShipping": 7.8,
     "color": [
       "Green"
     ],
@@ -10755,8 +11227,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 38.14,
-    "lowestPriceWithShipping": 59.99,
+    "marketPrice": 42.35,
+    "lowestPriceWithShipping": 36,
     "color": [
       "Green"
     ],
@@ -10781,8 +11253,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 0.66,
-    "lowestPriceWithShipping": 0.46,
+    "marketPrice": 1.03,
+    "lowestPriceWithShipping": 0.8,
     "color": [
       "Green"
     ],
@@ -10807,8 +11279,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 42.82,
-    "lowestPriceWithShipping": 42,
+    "marketPrice": 62.67,
+    "lowestPriceWithShipping": 64.9,
     "color": [
       "Green"
     ],
@@ -10833,8 +11305,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 8,
-    "lowestPriceWithShipping": 7.25,
+    "marketPrice": 8.32,
+    "lowestPriceWithShipping": 6.29,
     "color": [
       "Green"
     ],
@@ -10859,8 +11331,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 29.27,
-    "lowestPriceWithShipping": 30,
+    "marketPrice": 30.94,
+    "lowestPriceWithShipping": 60,
     "number": null,
     "productId": 483166
   },
@@ -10872,8 +11344,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 21.27,
-    "lowestPriceWithShipping": 15.25,
+    "marketPrice": 17.91,
+    "lowestPriceWithShipping": 18.85,
     "number": null,
     "productId": 509458
   },
@@ -10885,8 +11357,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 6.67,
-    "lowestPriceWithShipping": 4.96,
+    "marketPrice": 4.35,
+    "lowestPriceWithShipping": 2,
     "color": [
       "Red"
     ],
@@ -10908,8 +11380,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.1,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Red"
     ],
@@ -10931,8 +11403,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.43,
-    "lowestPriceWithShipping": 0.25,
+    "marketPrice": 0.36,
+    "lowestPriceWithShipping": 0.2,
     "color": [
       "Red"
     ],
@@ -10954,8 +11426,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.19,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.25,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Red"
     ],
@@ -10977,8 +11449,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 23.32,
-    "lowestPriceWithShipping": 21.72,
+    "marketPrice": 23.66,
+    "lowestPriceWithShipping": 22.77,
     "color": [
       "Red"
     ],
@@ -11000,8 +11472,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.2,
-    "lowestPriceWithShipping": 0.08,
+    "marketPrice": 0.18,
+    "lowestPriceWithShipping": 0.07,
     "color": [
       "Red"
     ],
@@ -11023,8 +11495,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 3.46,
-    "lowestPriceWithShipping": 2.38,
+    "marketPrice": 1.26,
+    "lowestPriceWithShipping": 0.9,
     "color": [
       "Red"
     ],
@@ -11046,8 +11518,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.78,
-    "lowestPriceWithShipping": 0.95,
+    "marketPrice": 1.58,
+    "lowestPriceWithShipping": 1.31,
     "color": [
       "Green"
     ],
@@ -11070,8 +11542,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.12,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Green"
     ],
@@ -11087,6 +11559,30 @@
     "productId": 516757
   },
   {
+    "productName": "Fleeting Lullaby (Starter Deck 11: Uta Deck Battle)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 20.79,
+    "lowestPriceWithShipping": 20.48,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Event"
+    ],
+    "attribute": null,
+    "subtypes": [
+      "FILM",
+      "Music"
+    ],
+    "number": "P-057",
+    "productId": 532111
+  },
+  {
     "productName": "Fossa",
     "setName": [
       "Pillars of Strength Pre Release Cards"
@@ -11094,8 +11590,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.99,
-    "lowestPriceWithShipping": 2.35,
+    "marketPrice": 3.01,
+    "lowestPriceWithShipping": 2.19,
     "color": [
       "Red"
     ],
@@ -11119,7 +11615,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.11,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -11144,8 +11640,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 13,
-    "lowestPriceWithShipping": 11,
+    "marketPrice": 8.95,
+    "lowestPriceWithShipping": 7.93,
     "color": [
       "Red"
     ],
@@ -11168,8 +11664,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.09,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Red"
     ],
@@ -11192,8 +11688,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 37.33,
-    "lowestPriceWithShipping": 39,
+    "marketPrice": 30.62,
+    "lowestPriceWithShipping": 21,
     "color": [
       "Purple"
     ],
@@ -11217,8 +11713,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.28,
-    "lowestPriceWithShipping": 0.2,
+    "marketPrice": 0.22,
+    "lowestPriceWithShipping": 0.15,
     "color": [
       "Purple"
     ],
@@ -11242,8 +11738,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.12,
-    "lowestPriceWithShipping": 0.07,
+    "marketPrice": 0.14,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Red"
     ],
@@ -11267,8 +11763,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.34,
-    "lowestPriceWithShipping": 1.25,
+    "marketPrice": 1.27,
+    "lowestPriceWithShipping": 0.65,
     "color": [
       "Red"
     ],
@@ -11292,8 +11788,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.16,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.08,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Purple"
     ],
@@ -11318,8 +11814,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.93,
-    "lowestPriceWithShipping": 3.38,
+    "marketPrice": 4.2,
+    "lowestPriceWithShipping": 4,
     "color": [
       "Green"
     ],
@@ -11343,8 +11839,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.15,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.21,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Red"
     ],
@@ -11368,7 +11864,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Green"
@@ -11394,8 +11890,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 2.9,
-    "lowestPriceWithShipping": 2.48,
+    "marketPrice": 2.99,
+    "lowestPriceWithShipping": 2.5,
     "color": [
       "Red"
     ],
@@ -11413,6 +11909,31 @@
     "productId": 485268
   },
   {
+    "productName": "Franky (CS 2023 Celebration Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "marketPrice": 9.83,
+    "lowestPriceWithShipping": 9.6,
+    "color": [
+      "Red"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Ranged"
+    ],
+    "subtypes": [
+      "Straw Hat Crew"
+    ],
+    "number": "OP01-021",
+    "productId": 525306
+  },
+  {
     "productName": "Franky (Gift Collection 2023)",
     "setName": [
       "One Piece Promotion Cards"
@@ -11420,8 +11941,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 2.24,
-    "lowestPriceWithShipping": 1.87,
+    "marketPrice": 2.78,
+    "lowestPriceWithShipping": 2,
     "color": [
       "Red"
     ],
@@ -11445,8 +11966,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.97,
-    "lowestPriceWithShipping": 0.5,
+    "marketPrice": 0.98,
+    "lowestPriceWithShipping": 0.95,
     "color": [
       "Red"
     ],
@@ -11470,7 +11991,7 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 0.3,
+    "marketPrice": 0.43,
     "lowestPriceWithShipping": 0.15,
     "color": [
       "Red"
@@ -11495,8 +12016,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 3.93,
-    "lowestPriceWithShipping": 10,
+    "marketPrice": 7.5,
+    "lowestPriceWithShipping": 4.2,
     "color": [
       "Red"
     ],
@@ -11571,8 +12092,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 14.17,
-    "lowestPriceWithShipping": 8.99,
+    "marketPrice": 12.09,
+    "lowestPriceWithShipping": 10.99,
     "color": [
       "Black"
     ],
@@ -11596,8 +12117,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.25,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.26,
+    "lowestPriceWithShipping": 0.15,
     "color": [
       "Black"
     ],
@@ -11646,8 +12167,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.44,
-    "lowestPriceWithShipping": 0.18,
+    "marketPrice": 0.45,
+    "lowestPriceWithShipping": 0.25,
     "color": [
       "Black"
     ],
@@ -11721,8 +12242,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.57,
-    "lowestPriceWithShipping": 0.4,
+    "marketPrice": 0.61,
+    "lowestPriceWithShipping": 0.39,
     "color": [
       "Blue"
     ],
@@ -11746,8 +12267,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.05,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
     ],
@@ -11771,8 +12292,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.67,
-    "lowestPriceWithShipping": 0.6,
+    "marketPrice": 1.15,
+    "lowestPriceWithShipping": 18.99,
     "color": [
       "Purple"
     ],
@@ -11795,7 +12316,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -11819,8 +12340,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.08,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
     ],
@@ -11842,8 +12363,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 13.86,
-    "lowestPriceWithShipping": 9.89,
+    "marketPrice": 5.65,
+    "lowestPriceWithShipping": 2.5,
     "color": [
       "Purple"
     ],
@@ -11865,8 +12386,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.48,
-    "lowestPriceWithShipping": 0.3,
+    "marketPrice": 1.24,
+    "lowestPriceWithShipping": 0.32,
     "color": [
       "Blue"
     ],
@@ -11891,8 +12412,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.39,
-    "lowestPriceWithShipping": 1,
+    "marketPrice": 1.51,
+    "lowestPriceWithShipping": 1.24,
     "color": [
       "Blue"
     ],
@@ -11917,8 +12438,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.22,
-    "lowestPriceWithShipping": 0.11,
+    "marketPrice": 0.24,
+    "lowestPriceWithShipping": 0.08,
     "color": [
       "Blue"
     ],
@@ -11943,7 +12464,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.11,
     "lowestPriceWithShipping": 0.03,
     "color": [
       "Blue"
@@ -11969,8 +12490,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 9.47,
-    "lowestPriceWithShipping": 7.99,
+    "marketPrice": 8.74,
+    "lowestPriceWithShipping": 9.42,
     "color": [
       "Blue"
     ],
@@ -11995,8 +12516,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 12.85,
-    "lowestPriceWithShipping": 12,
+    "marketPrice": 25.45,
+    "lowestPriceWithShipping": 23.94,
     "color": [
       "Blue"
     ],
@@ -12021,8 +12542,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.58,
-    "lowestPriceWithShipping": 0.3,
+    "marketPrice": 0.63,
+    "lowestPriceWithShipping": 0.37,
     "color": [
       "Yellow"
     ],
@@ -12047,8 +12568,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 19.49,
-    "lowestPriceWithShipping": 19.84,
+    "marketPrice": 31.05,
+    "lowestPriceWithShipping": 28.95,
     "color": [
       "Yellow"
     ],
@@ -12066,6 +12587,31 @@
     "productId": 528169
   },
   {
+    "productName": "General Franky (CS 2023 Event Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 26.77,
+    "lowestPriceWithShipping": 13,
+    "color": [
+      "Red"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Ranged"
+    ],
+    "subtypes": [
+      "Straw Hat Crew"
+    ],
+    "number": "P-027",
+    "productId": 525298
+  },
+  {
     "productName": "General Franky (Event Pack Vol. 2)",
     "setName": [
       "One Piece Promotion Cards"
@@ -12073,8 +12619,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 6.36,
-    "lowestPriceWithShipping": 7.15,
+    "marketPrice": 12.36,
+    "lowestPriceWithShipping": 12.27,
     "color": [
       "Red"
     ],
@@ -12098,7 +12644,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.35,
+    "marketPrice": 0.37,
     "lowestPriceWithShipping": 0.3,
     "color": [
       "Blue"
@@ -12123,7 +12669,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.04,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
@@ -12148,8 +12694,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 40.73,
-    "lowestPriceWithShipping": 40.9,
+    "marketPrice": 51.21,
+    "lowestPriceWithShipping": 51,
     "number": null,
     "productId": 484943
   },
@@ -12161,8 +12707,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 208.45,
-    "lowestPriceWithShipping": 224.95,
+    "marketPrice": 233.01,
+    "lowestPriceWithShipping": 324.7,
     "number": null,
     "productId": 493744
   },
@@ -12174,8 +12720,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.68,
-    "lowestPriceWithShipping": 2.5,
+    "marketPrice": 2.09,
+    "lowestPriceWithShipping": 1.88,
     "color": [
       "Purple"
     ],
@@ -12201,7 +12747,7 @@
       "Rare"
     ],
     "marketPrice": 0.14,
-    "lowestPriceWithShipping": 0.06,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Green"
     ],
@@ -12226,8 +12772,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 7.42,
-    "lowestPriceWithShipping": 7.31,
+    "marketPrice": 7.96,
+    "lowestPriceWithShipping": 8.05,
     "color": [
       "Green"
     ],
@@ -12243,6 +12789,32 @@
     ],
     "number": "OP03-024",
     "productId": 498862
+  },
+  {
+    "productName": "Ginrummy",
+    "setName": [
+      "Super Pre Release Starter Deck 4 Animal Kingdom Pirates"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 0.26,
+    "lowestPriceWithShipping": 0.1,
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "Animal Kingdom Pirates",
+      "SMILE"
+    ],
+    "number": "ST04-009",
+    "productId": 425175
   },
   {
     "productName": "Ginrummy",
@@ -12271,32 +12843,6 @@
     "productId": 288287
   },
   {
-    "productName": "Ginrummy",
-    "setName": [
-      "Super Pre Release Starter Deck 4 Animal Kingdom Pirates"
-    ],
-    "rarityName": [
-      "Common"
-    ],
-    "marketPrice": 0.28,
-    "lowestPriceWithShipping": 0.1,
-    "color": [
-      "Purple"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Strike"
-    ],
-    "subtypes": [
-      "Animal Kingdom Pirates",
-      "SMILE"
-    ],
-    "number": "ST04-009",
-    "productId": 425175
-  },
-  {
     "productName": "Giolla",
     "setName": [
       "Kingdoms of Intrigue Pre Release Cards"
@@ -12304,7 +12850,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.45,
+    "marketPrice": 0.43,
     "lowestPriceWithShipping": 0.39,
     "color": [
       "Green"
@@ -12329,7 +12875,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.04,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -12354,8 +12900,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.03,
+    "marketPrice": 0.04,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
     ],
@@ -12379,8 +12925,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 9.99,
-    "lowestPriceWithShipping": 8.98,
+    "marketPrice": 4.41,
+    "lowestPriceWithShipping": 2,
     "color": [
       "Green"
     ],
@@ -12404,8 +12950,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.24,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.17,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Red"
     ],
@@ -12429,7 +12975,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Purple"
@@ -12454,8 +13000,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 18.35,
-    "lowestPriceWithShipping": 18.5,
+    "marketPrice": 18.03,
+    "lowestPriceWithShipping": 18.99,
     "color": [
       "Red"
     ],
@@ -12479,8 +13025,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 19.67,
-    "lowestPriceWithShipping": 19.97,
+    "marketPrice": 18.44,
+    "lowestPriceWithShipping": 18,
     "color": [
       "Black"
     ],
@@ -12502,7 +13048,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Red"
@@ -12525,8 +13071,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 10.64,
-    "lowestPriceWithShipping": 6.29,
+    "marketPrice": 6,
+    "lowestPriceWithShipping": 3.99,
     "color": [
       "Red"
     ],
@@ -12549,8 +13095,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.69,
-    "lowestPriceWithShipping": 3.25,
+    "marketPrice": 3.4,
+    "lowestPriceWithShipping": 2.94,
     "color": [
       "Red"
     ],
@@ -12573,8 +13119,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.14,
-    "lowestPriceWithShipping": 0.09,
+    "marketPrice": 0.15,
+    "lowestPriceWithShipping": 0.07,
     "color": [
       "Black"
     ],
@@ -12596,8 +13142,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.96,
-    "lowestPriceWithShipping": 0.69,
+    "marketPrice": 1.04,
+    "lowestPriceWithShipping": 0.8,
     "color": [
       "Red"
     ],
@@ -12620,8 +13166,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 4.58,
-    "lowestPriceWithShipping": 3.89,
+    "marketPrice": 4.38,
+    "lowestPriceWithShipping": 3,
     "color": [
       "Blue"
     ],
@@ -12644,7 +13190,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.1,
+    "marketPrice": 0.13,
     "lowestPriceWithShipping": 0.03,
     "color": [
       "Blue"
@@ -12669,7 +13215,7 @@
       "Common"
     ],
     "marketPrice": 0.17,
-    "lowestPriceWithShipping": 0.06,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
     ],
@@ -12691,8 +13237,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 2.82,
-    "lowestPriceWithShipping": 2.48,
+    "marketPrice": 2.04,
+    "lowestPriceWithShipping": 1.65,
     "color": [
       "Purple"
     ],
@@ -12715,8 +13261,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.96,
-    "lowestPriceWithShipping": 2.93,
+    "marketPrice": 3.25,
+    "lowestPriceWithShipping": 3.6,
     "color": [
       "Red"
     ],
@@ -12739,8 +13285,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.3,
-    "lowestPriceWithShipping": 0.6,
+    "marketPrice": 1.95,
+    "lowestPriceWithShipping": 1.19,
     "color": [
       "Red"
     ],
@@ -12763,7 +13309,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.11,
+    "marketPrice": 0.12,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Black"
@@ -12787,8 +13333,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 8.63,
-    "lowestPriceWithShipping": 9.5,
+    "marketPrice": 9.24,
+    "lowestPriceWithShipping": 10.19,
     "color": [
       "Black"
     ],
@@ -12811,8 +13357,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.07,
+    "marketPrice": 0.17,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
     ],
@@ -12835,7 +13381,7 @@
       "Common"
     ],
     "marketPrice": 0.32,
-    "lowestPriceWithShipping": 0.2,
+    "lowestPriceWithShipping": 0.25,
     "color": [
       "Black"
     ],
@@ -12857,8 +13403,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.44,
-    "lowestPriceWithShipping": 0.25,
+    "marketPrice": 0.62,
+    "lowestPriceWithShipping": 0.35,
     "color": [
       "Blue"
     ],
@@ -12881,8 +13427,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.72,
-    "lowestPriceWithShipping": 0.33,
+    "marketPrice": 0.44,
+    "lowestPriceWithShipping": 0.23,
     "color": [
       "Blue"
     ],
@@ -12904,8 +13450,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.79,
-    "lowestPriceWithShipping": 0.65,
+    "marketPrice": 0.77,
+    "lowestPriceWithShipping": 0.64,
     "color": [
       "Yellow"
     ],
@@ -12928,7 +13474,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
@@ -12952,8 +13498,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.14,
-    "lowestPriceWithShipping": 0.08,
+    "marketPrice": 0.16,
+    "lowestPriceWithShipping": 0.09,
     "color": [
       "Black"
     ],
@@ -12977,7 +13523,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 7.51,
+    "marketPrice": 7.06,
     "lowestPriceWithShipping": 6.49,
     "color": [
       "Black"
@@ -13002,8 +13548,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.03,
+    "marketPrice": 0.05,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
     ],
@@ -13028,8 +13574,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 18,
-    "lowestPriceWithShipping": 17.79,
+    "marketPrice": 9.47,
+    "lowestPriceWithShipping": 6.25,
     "color": [
       "Blue"
     ],
@@ -13054,8 +13600,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.019,
+    "marketPrice": 0.06,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
     ],
@@ -13080,8 +13626,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.16,
-    "lowestPriceWithShipping": 2.35,
+    "marketPrice": 1.44,
+    "lowestPriceWithShipping": 0.97,
     "color": [
       "Red"
     ],
@@ -13106,8 +13652,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.4,
-    "lowestPriceWithShipping": 1.25,
+    "marketPrice": 1.38,
+    "lowestPriceWithShipping": 1.38,
     "color": [
       "Black"
     ],
@@ -13133,7 +13679,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Black"
@@ -13160,7 +13706,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -13186,8 +13732,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 4.01,
-    "lowestPriceWithShipping": 3.74,
+    "marketPrice": 3.65,
+    "lowestPriceWithShipping": 0.99,
     "color": [
       "Black"
     ],
@@ -13212,8 +13758,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.11,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.07,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
     ],
@@ -13263,8 +13809,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.45,
-    "lowestPriceWithShipping": 0.35,
+    "marketPrice": 0.5,
+    "lowestPriceWithShipping": 0.4,
     "color": [
       "Blue"
     ],
@@ -13288,7 +13834,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.26,
+    "marketPrice": 0.31,
     "lowestPriceWithShipping": 0.07,
     "color": [
       "Purple"
@@ -13313,8 +13859,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.54,
-    "lowestPriceWithShipping": 3.29,
+    "marketPrice": 2.7,
+    "lowestPriceWithShipping": 4,
     "color": [
       "Red"
     ],
@@ -13337,7 +13883,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -13361,8 +13907,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.92,
-    "lowestPriceWithShipping": 1.79,
+    "marketPrice": 2.1,
+    "lowestPriceWithShipping": 1.74,
     "color": [
       "Red"
     ],
@@ -13411,8 +13957,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.12,
-    "lowestPriceWithShipping": 0.09,
+    "marketPrice": 0.17,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Green"
     ],
@@ -13438,8 +13984,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 6.22,
-    "lowestPriceWithShipping": 5.79,
+    "marketPrice": 8.23,
+    "lowestPriceWithShipping": 8.64,
     "color": [
       "Green"
     ],
@@ -13465,8 +14011,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.11,
-    "lowestPriceWithShipping": 0.03,
+    "marketPrice": 0.08,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
     ],
@@ -13489,7 +14035,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.1,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -13514,7 +14060,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.21,
+    "marketPrice": 0.18,
     "lowestPriceWithShipping": 0.1,
     "color": [
       "Green"
@@ -13539,8 +14085,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.12,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.11,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Purple"
     ],
@@ -13564,7 +14110,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.16,
+    "marketPrice": 0.14,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
@@ -13588,7 +14134,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.1,
+    "marketPrice": 0.15,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Black"
@@ -13613,8 +14159,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.14,
-    "lowestPriceWithShipping": 0.68,
+    "marketPrice": 1.01,
+    "lowestPriceWithShipping": 0.69,
     "color": [
       "Black"
     ],
@@ -13638,7 +14184,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.38,
+    "marketPrice": 0.41,
     "lowestPriceWithShipping": 0.2,
     "color": [
       "Black"
@@ -13663,8 +14209,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.4,
-    "lowestPriceWithShipping": 1,
+    "marketPrice": 2.17,
+    "lowestPriceWithShipping": 2,
     "color": [
       "Black"
     ],
@@ -13688,7 +14234,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -13713,8 +14259,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 5.47,
-    "lowestPriceWithShipping": 8.97,
+    "marketPrice": 10.64,
+    "lowestPriceWithShipping": 11.37,
     "color": [
       "Black"
     ],
@@ -13738,8 +14284,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 0.35,
-    "lowestPriceWithShipping": 0.19,
+    "marketPrice": 0.4,
+    "lowestPriceWithShipping": 0.2,
     "color": [
       "Red"
     ],
@@ -13764,8 +14310,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 2.57,
-    "lowestPriceWithShipping": 1.79,
+    "marketPrice": 3.53,
+    "lowestPriceWithShipping": 2.99,
     "color": [
       "Black"
     ],
@@ -13789,8 +14335,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.37,
-    "lowestPriceWithShipping": 1,
+    "marketPrice": 1.29,
+    "lowestPriceWithShipping": 0.98,
     "color": [
       "Yellow"
     ],
@@ -13815,7 +14361,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
@@ -13841,8 +14387,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
-    "lowestPriceWithShipping": 0.03,
+    "marketPrice": 0.06,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
     ],
@@ -13866,8 +14412,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 16.37,
-    "lowestPriceWithShipping": 18.96,
+    "marketPrice": 20.05,
+    "lowestPriceWithShipping": 19.98,
     "color": [
       "Black"
     ],
@@ -13891,8 +14437,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.68,
-    "lowestPriceWithShipping": 0.25,
+    "marketPrice": 0.74,
+    "lowestPriceWithShipping": 0.35,
     "color": [
       "Black"
     ],
@@ -13916,8 +14462,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.15,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Blue"
     ],
@@ -13941,7 +14487,8 @@
     "rarityName": [
       "Common"
     ],
-    "lowestPriceWithShipping": 3.72,
+    "marketPrice": 4.62,
+    "lowestPriceWithShipping": 1.98,
     "color": [
       "Yellow"
     ],
@@ -13963,8 +14510,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.11,
-    "lowestPriceWithShipping": 0.03,
+    "marketPrice": 0.06,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
     ],
@@ -13986,8 +14533,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.17,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.15,
+    "lowestPriceWithShipping": 0.08,
     "color": [
       "Purple"
     ],
@@ -14013,8 +14560,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 4.39,
-    "lowestPriceWithShipping": 4.21,
+    "marketPrice": 14.93,
+    "lowestPriceWithShipping": 11.99,
     "color": [
       "Purple"
     ],
@@ -14066,8 +14613,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 21.61,
-    "lowestPriceWithShipping": 16.74,
+    "marketPrice": 17.4,
+    "lowestPriceWithShipping": 14.99,
     "color": [
       "Yellow"
     ],
@@ -14092,8 +14639,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.14,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Yellow"
     ],
@@ -14118,8 +14665,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 6.43,
-    "lowestPriceWithShipping": 6.47,
+    "marketPrice": 2.91,
+    "lowestPriceWithShipping": 4.13,
     "color": [
       "Purple"
     ],
@@ -14143,8 +14690,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.05,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
     ],
@@ -14168,8 +14715,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.11,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.09,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Yellow"
     ],
@@ -14193,8 +14740,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 9,
-    "lowestPriceWithShipping": 7.97,
+    "marketPrice": 2.8,
+    "lowestPriceWithShipping": 2,
     "color": [
       "Yellow"
     ],
@@ -14218,8 +14765,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.38,
-    "lowestPriceWithShipping": 0.13,
+    "marketPrice": 0.28,
+    "lowestPriceWithShipping": 0.09,
     "color": [
       "Blue"
     ],
@@ -14241,7 +14788,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.04,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -14265,8 +14812,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.63,
-    "lowestPriceWithShipping": 0.34,
+    "marketPrice": 0.57,
+    "lowestPriceWithShipping": 0.48,
     "color": [
       "Purple"
     ],
@@ -14289,8 +14836,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.16,
-    "lowestPriceWithShipping": 0.07,
+    "marketPrice": 0.15,
+    "lowestPriceWithShipping": 0.08,
     "color": [
       "Purple"
     ],
@@ -14312,8 +14859,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.77,
-    "lowestPriceWithShipping": 1,
+    "marketPrice": 0.98,
+    "lowestPriceWithShipping": 1.95,
     "color": [
       "Purple"
     ],
@@ -14335,7 +14882,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -14360,7 +14907,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "lowestPriceWithShipping": 9.89,
+    "marketPrice": 4.85,
+    "lowestPriceWithShipping": 5.99,
     "color": [
       "Black"
     ],
@@ -14382,8 +14930,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.03,
+    "marketPrice": 0.06,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
     ],
@@ -14405,8 +14953,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 2.76,
-    "lowestPriceWithShipping": 2.01,
+    "marketPrice": 2.94,
+    "lowestPriceWithShipping": 3.13,
     "color": [
       "Red"
     ],
@@ -14428,8 +14976,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 4.57,
-    "lowestPriceWithShipping": 4,
+    "marketPrice": 4.65,
+    "lowestPriceWithShipping": 4.62,
     "color": [
       "Green"
     ],
@@ -14445,6 +14993,54 @@
     "productId": 454250
   },
   {
+    "productName": "I'm invincible",
+    "setName": [
+      "Starter Deck 11 Uta"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 0.77,
+    "lowestPriceWithShipping": 0.23,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Event"
+    ],
+    "attribute": null,
+    "subtypes": [
+      "FILM",
+      "Music"
+    ],
+    "number": "ST11-005",
+    "productId": 533883
+  },
+  {
+    "productName": "I'm invincible (Starter Deck 11: Uta Deck Battle)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 15.79,
+    "lowestPriceWithShipping": 15.98,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Event"
+    ],
+    "attribute": null,
+    "subtypes": [
+      "FILM",
+      "Music"
+    ],
+    "number": "ST11-005",
+    "productId": 532109
+  },
+  {
     "productName": "Ice Age",
     "setName": [
       "Paramount War"
@@ -14452,8 +15048,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 2.29,
-    "lowestPriceWithShipping": 1.88,
+    "marketPrice": 1.11,
+    "lowestPriceWithShipping": 0.95,
     "color": [
       "Black"
     ],
@@ -14475,8 +15071,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 16.74,
-    "lowestPriceWithShipping": 16.9,
+    "marketPrice": 16.15,
+    "lowestPriceWithShipping": 10.5,
     "color": [
       "Black"
     ],
@@ -14498,7 +15094,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.73,
+    "marketPrice": 0.72,
     "lowestPriceWithShipping": 0.6,
     "color": [
       "Blue"
@@ -14524,7 +15120,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
@@ -14550,7 +15146,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.04,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -14576,8 +15172,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 2.75,
-    "lowestPriceWithShipping": 1.96,
+    "marketPrice": 2.32,
+    "lowestPriceWithShipping": 1.85,
     "color": [
       "Purple"
     ],
@@ -14602,8 +15198,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.13,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Purple"
     ],
@@ -14628,8 +15224,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 30.28,
-    "lowestPriceWithShipping": 32.96,
+    "marketPrice": 63.45,
+    "lowestPriceWithShipping": 54,
     "color": [
       "Purple"
     ],
@@ -14651,8 +15247,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.82,
-    "lowestPriceWithShipping": 1.5,
+    "marketPrice": 1.93,
+    "lowestPriceWithShipping": 1,
     "color": [
       "Black"
     ],
@@ -14676,7 +15272,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.1,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -14701,7 +15297,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -14726,8 +15322,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.32,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.25,
+    "lowestPriceWithShipping": 0.18,
     "color": [
       "Yellow"
     ],
@@ -14750,8 +15346,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 19.62,
-    "lowestPriceWithShipping": 18.69,
+    "marketPrice": 19.35,
+    "lowestPriceWithShipping": 17.96,
     "color": [
       "Yellow"
     ],
@@ -14774,8 +15370,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.08,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.06,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
     ],
@@ -14797,8 +15393,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.51,
-    "lowestPriceWithShipping": 1.2,
+    "marketPrice": 2.54,
+    "lowestPriceWithShipping": 4.19,
     "color": [
       "Purple"
     ],
@@ -14820,8 +15416,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 5.07,
-    "lowestPriceWithShipping": 2,
+    "marketPrice": 3.97,
+    "lowestPriceWithShipping": 4.11,
     "color": [
       "Blue"
     ],
@@ -14843,8 +15439,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.14,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.16,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Blue"
     ],
@@ -14866,8 +15462,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.37,
-    "lowestPriceWithShipping": 0.17,
+    "marketPrice": 0.34,
+    "lowestPriceWithShipping": 0.19,
     "color": [
       "Red"
     ],
@@ -14889,7 +15485,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.1748,
+    "marketPrice": 0.16,
     "lowestPriceWithShipping": 0.1,
     "color": [
       "Red"
@@ -14914,8 +15510,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 37.55,
-    "lowestPriceWithShipping": 22,
+    "marketPrice": 27.7,
+    "lowestPriceWithShipping": 21.99,
     "color": [
       "Red"
     ],
@@ -14939,7 +15535,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.14,
+    "marketPrice": 0.12,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Blue"
@@ -14965,7 +15561,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -14993,7 +15589,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Green"
@@ -15020,8 +15616,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.56,
-    "lowestPriceWithShipping": 0.57,
+    "marketPrice": 0.9,
+    "lowestPriceWithShipping": 1,
     "color": [
       "Green"
     ],
@@ -15047,7 +15643,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.88,
+    "marketPrice": 3.33,
     "lowestPriceWithShipping": 1.99,
     "color": [
       "Green"
@@ -15074,7 +15670,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.03,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
@@ -15099,8 +15695,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.97,
-    "lowestPriceWithShipping": 1.4,
+    "marketPrice": 2.05,
+    "lowestPriceWithShipping": 0.97,
     "color": [
       "Blue"
     ],
@@ -15124,8 +15720,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.11,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.09,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
     ],
@@ -15149,8 +15745,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.09,
-    "lowestPriceWithShipping": 0.76,
+    "marketPrice": 1.38,
+    "lowestPriceWithShipping": 1.19,
     "color": [
       "Black"
     ],
@@ -15174,8 +15770,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.08,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.11,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Green",
       "Black"
@@ -15200,8 +15796,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 16,
-    "lowestPriceWithShipping": 14.69,
+    "marketPrice": 17.29,
+    "lowestPriceWithShipping": 13.99,
     "color": [
       "Black"
     ],
@@ -15225,8 +15821,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 18.64,
-    "lowestPriceWithShipping": 19.95,
+    "marketPrice": 24.75,
+    "lowestPriceWithShipping": 23,
     "color": [
       "Green",
       "Black"
@@ -15251,7 +15847,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.07,
+    "marketPrice": 1.13,
     "lowestPriceWithShipping": 0.79,
     "color": [
       "Black"
@@ -15276,8 +15872,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.03,
+    "marketPrice": 0.12,
+    "lowestPriceWithShipping": 0.07,
     "color": [
       "Black"
     ],
@@ -15301,7 +15897,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
@@ -15324,8 +15920,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.97,
-    "lowestPriceWithShipping": 0.98,
+    "marketPrice": 1.7,
+    "lowestPriceWithShipping": 1.99,
     "color": [
       "Blue"
     ],
@@ -15347,8 +15943,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.36,
-    "lowestPriceWithShipping": 0.2,
+    "marketPrice": 0.28,
+    "lowestPriceWithShipping": 0.18,
     "color": [
       "Red"
     ],
@@ -15373,8 +15969,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.72,
-    "lowestPriceWithShipping": 1.25,
+    "marketPrice": 3.84,
+    "lowestPriceWithShipping": 3.1,
     "color": [
       "Green"
     ],
@@ -15392,6 +15988,32 @@
     "productId": 454554
   },
   {
+    "productName": "Izo (CS 2023 Celebration Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "marketPrice": 37.85,
+    "lowestPriceWithShipping": 40.99,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Ranged"
+    ],
+    "subtypes": [
+      "Former Whitebeard Pirates",
+      "Land of Wano"
+    ],
+    "number": "OP01-033",
+    "productId": 525307
+  },
+  {
     "productName": "Izo (Tournament Pack Vol. 2)",
     "setName": [
       "One Piece Promotion Cards"
@@ -15399,8 +16021,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 2.42,
-    "lowestPriceWithShipping": 1.97,
+    "marketPrice": 5.35,
+    "lowestPriceWithShipping": 6,
     "color": [
       "Green"
     ],
@@ -15425,8 +16047,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 25.81,
-    "lowestPriceWithShipping": 21.89,
+    "marketPrice": 19.26,
+    "lowestPriceWithShipping": 16,
     "color": [
       "Green"
     ],
@@ -15451,8 +16073,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.86,
-    "lowestPriceWithShipping": 0.95,
+    "marketPrice": 1.08,
+    "lowestPriceWithShipping": 1.98,
     "color": [
       "Black"
     ],
@@ -15476,7 +16098,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -15526,8 +16148,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.8,
-    "lowestPriceWithShipping": 0.68,
+    "marketPrice": 0.81,
+    "lowestPriceWithShipping": 0.75,
     "color": [
       "Blue"
     ],
@@ -15551,7 +16173,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.19,
+    "marketPrice": 0.26,
     "lowestPriceWithShipping": 0.1,
     "color": [
       "Purple"
@@ -15576,8 +16198,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.06,
-    "lowestPriceWithShipping": 0.93,
+    "marketPrice": 1.02,
+    "lowestPriceWithShipping": 0.68,
     "color": [
       "Purple"
     ],
@@ -15601,8 +16223,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.23,
-    "lowestPriceWithShipping": 0.12,
+    "marketPrice": 0.19,
+    "lowestPriceWithShipping": 0.08,
     "color": [
       "Purple"
     ],
@@ -15626,8 +16248,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 16.7,
-    "lowestPriceWithShipping": 19.25,
+    "marketPrice": 19.49,
+    "lowestPriceWithShipping": 78.99,
     "color": [
       "Purple"
     ],
@@ -15651,8 +16273,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 14.49,
-    "lowestPriceWithShipping": 16.99,
+    "marketPrice": 18.36,
+    "lowestPriceWithShipping": 20.69,
     "color": [
       "Purple"
     ],
@@ -15700,8 +16322,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 15.84,
-    "lowestPriceWithShipping": 17.49,
+    "marketPrice": 17.73,
+    "lowestPriceWithShipping": 65,
     "color": [
       "Purple"
     ],
@@ -15725,8 +16347,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 10.24,
-    "lowestPriceWithShipping": 12.5,
+    "marketPrice": 13.59,
+    "lowestPriceWithShipping": 24.99,
     "color": [
       "Purple"
     ],
@@ -15773,8 +16395,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 12.47,
-    "lowestPriceWithShipping": 14.01,
+    "marketPrice": 22.01,
+    "lowestPriceWithShipping": 15.01,
     "color": [
       "Purple"
     ],
@@ -15798,7 +16420,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -15824,8 +16446,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.61,
-    "lowestPriceWithShipping": 0.5,
+    "marketPrice": 0.66,
+    "lowestPriceWithShipping": 0.48,
     "color": [
       "Black"
     ],
@@ -15875,7 +16497,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -15900,8 +16522,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.116,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.17,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Green"
     ],
@@ -15926,7 +16548,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.6,
+    "marketPrice": 0.66,
     "lowestPriceWithShipping": 0.4,
     "color": [
       "Black"
@@ -15951,8 +16573,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.08,
+    "marketPrice": 0.17,
+    "lowestPriceWithShipping": 0.06,
     "color": [
       "Purple"
     ],
@@ -16001,7 +16623,7 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 0.19,
+    "marketPrice": 0.28,
     "lowestPriceWithShipping": 0.1,
     "color": [
       "Red"
@@ -16027,8 +16649,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.38,
-    "lowestPriceWithShipping": 0.25,
+    "marketPrice": 0.45,
+    "lowestPriceWithShipping": 0.26,
     "color": [
       "Black"
     ],
@@ -16052,7 +16674,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.04,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -16077,8 +16699,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.68,
-    "lowestPriceWithShipping": 0.4,
+    "marketPrice": 1.1,
+    "lowestPriceWithShipping": 0.89,
     "color": [
       "Green"
     ],
@@ -16103,8 +16725,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.57,
-    "lowestPriceWithShipping": 1.42,
+    "marketPrice": 3.45,
+    "lowestPriceWithShipping": 3.44,
     "color": [
       "Green"
     ],
@@ -16122,6 +16744,32 @@
     "productId": 418677
   },
   {
+    "productName": "Jewelry Bonney (CS 2023 Celebration Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 121.83,
+    "lowestPriceWithShipping": 122,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Special"
+    ],
+    "subtypes": [
+      "Bonney Pirates",
+      "Supernovas"
+    ],
+    "number": "ST02-007",
+    "productId": 525326
+  },
+  {
     "productName": "Jewelry Bonney (Tournament Pack Vol. 3) [Participant]",
     "setName": [
       "One Piece Promotion Cards"
@@ -16129,8 +16777,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.05,
-    "lowestPriceWithShipping": 0.96,
+    "marketPrice": 3.48,
+    "lowestPriceWithShipping": 3.29,
     "color": [
       "Green"
     ],
@@ -16155,8 +16803,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 21.99,
-    "lowestPriceWithShipping": 22.99,
+    "marketPrice": 47.29,
+    "lowestPriceWithShipping": 38.93,
     "color": [
       "Green"
     ],
@@ -16176,39 +16824,13 @@
   {
     "productName": "Jinbe",
     "setName": [
-      "Paramount War Pre Release Cards"
-    ],
-    "rarityName": [
-      "Common"
-    ],
-    "marketPrice": 1.04,
-    "lowestPriceWithShipping": 1.15,
-    "color": [
-      "Green"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Strike"
-    ],
-    "subtypes": [
-      "Fish-Man",
-      "Straw Hat Crew"
-    ],
-    "number": "OP02-033",
-    "productId": 486652
-  },
-  {
-    "productName": "Jinbe",
-    "setName": [
       "Ultra Deck The Three Captains"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.8,
-    "lowestPriceWithShipping": 0.29,
+    "marketPrice": 0.62,
+    "lowestPriceWithShipping": 0.48,
     "color": [
       "Red"
     ],
@@ -16228,13 +16850,39 @@
   {
     "productName": "Jinbe",
     "setName": [
+      "Paramount War Pre Release Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 1.37,
+    "lowestPriceWithShipping": 1.14,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "Fish-Man",
+      "Straw Hat Crew"
+    ],
+    "number": "OP02-033",
+    "productId": 486652
+  },
+  {
+    "productName": "Jinbe",
+    "setName": [
       "Super Pre Release Starter Deck 1 Straw Hat Crew"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.31,
-    "lowestPriceWithShipping": 0.2,
+    "marketPrice": 0.32,
+    "lowestPriceWithShipping": 0.16,
     "color": [
       "Red"
     ],
@@ -16259,8 +16907,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.11,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.1,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
     ],
@@ -16285,8 +16933,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.07,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Blue"
     ],
@@ -16312,7 +16960,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -16339,8 +16987,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 4.76,
-    "lowestPriceWithShipping": 3.97,
+    "marketPrice": 3.85,
+    "lowestPriceWithShipping": 0.99,
     "color": [
       "Purple"
     ],
@@ -16365,7 +17013,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.12,
+    "marketPrice": 0.1,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -16391,8 +17039,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.42,
-    "lowestPriceWithShipping": 0.25,
+    "marketPrice": 0.37,
+    "lowestPriceWithShipping": 0.2,
     "color": [
       "Blue"
     ],
@@ -16418,8 +17066,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.44,
-    "lowestPriceWithShipping": 1.45,
+    "marketPrice": 1.33,
+    "lowestPriceWithShipping": 1,
     "color": [
       "Red"
     ],
@@ -16445,7 +17093,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.15,
+    "marketPrice": 0.12,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Red"
@@ -16471,7 +17119,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.22,
+    "marketPrice": 0.18,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Blue"
@@ -16490,6 +17138,33 @@
     "productId": 454600
   },
   {
+    "productName": "Jinbe (CS 2023 Event Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 61.95,
+    "lowestPriceWithShipping": 39.9,
+    "color": [
+      "Blue"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "Fish-Man",
+      "The Seven Warlords of the Sea",
+      "The Sun Pirates"
+    ],
+    "number": "P-030",
+    "productId": 525301
+  },
+  {
     "productName": "Jinbe (Event Pack Vol. 1)",
     "setName": [
       "One Piece Promotion Cards"
@@ -16497,8 +17172,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 33.74,
-    "lowestPriceWithShipping": 35.98,
+    "marketPrice": 32.89,
+    "lowestPriceWithShipping": 30,
     "color": [
       "Blue"
     ],
@@ -16524,8 +17199,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.62,
-    "lowestPriceWithShipping": 1.39,
+    "marketPrice": 2.07,
+    "lowestPriceWithShipping": 1.74,
     "color": [
       "Red"
     ],
@@ -16550,8 +17225,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 2.05,
-    "lowestPriceWithShipping": 1.51,
+    "marketPrice": 1.19,
+    "lowestPriceWithShipping": 0.94,
     "color": [
       "Red"
     ],
@@ -16577,7 +17252,7 @@
       "Common"
     ],
     "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.04,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
     ],
@@ -16602,8 +17277,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 7.88,
-    "lowestPriceWithShipping": 8.78,
+    "marketPrice": 4.05,
+    "lowestPriceWithShipping": 2.95,
     "color": [
       "Blue"
     ],
@@ -16628,8 +17303,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.8,
-    "lowestPriceWithShipping": 0.49,
+    "marketPrice": 0.59,
+    "lowestPriceWithShipping": 0.46,
     "color": [
       "Red"
     ],
@@ -16653,8 +17328,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 173.8,
-    "lowestPriceWithShipping": 179.92,
+    "marketPrice": 188.82,
+    "lowestPriceWithShipping": 249.99,
     "color": [
       "Red"
     ],
@@ -16678,8 +17353,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.11,
-    "lowestPriceWithShipping": 0.85,
+    "marketPrice": 1.44,
+    "lowestPriceWithShipping": 0.99,
     "color": [
       "Red"
     ],
@@ -16703,8 +17378,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 7.24,
-    "lowestPriceWithShipping": 6,
+    "marketPrice": 16.14,
+    "lowestPriceWithShipping": 13.75,
     "color": [
       "Red"
     ],
@@ -16728,10 +17403,23 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 5.31,
-    "lowestPriceWithShipping": 5,
+    "marketPrice": 10.29,
+    "lowestPriceWithShipping": 8.95,
     "number": null,
     "productId": 502570
+  },
+  {
+    "productName": "Judge Pack Vol. 2",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "None"
+    ],
+    "marketPrice": 13,
+    "lowestPriceWithShipping": 13,
+    "number": null,
+    "productId": 536257
   },
   {
     "productName": "Judgment of Hell",
@@ -16741,8 +17429,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.99,
-    "lowestPriceWithShipping": 0.65,
+    "marketPrice": 0.86,
+    "lowestPriceWithShipping": 0.56,
     "color": [
       "Purple"
     ],
@@ -16764,8 +17452,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.07,
-    "lowestPriceWithShipping": 0.4,
+    "marketPrice": 0.73,
+    "lowestPriceWithShipping": 0.45,
     "color": [
       "Blue"
     ],
@@ -16790,7 +17478,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.13,
     "lowestPriceWithShipping": 0.07,
     "color": [
       "Yellow"
@@ -16816,8 +17504,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 13.23,
-    "lowestPriceWithShipping": 17.5,
+    "marketPrice": 18.38,
+    "lowestPriceWithShipping": 12.48,
     "color": [
       "Purple"
     ],
@@ -16842,8 +17530,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.29,
-    "lowestPriceWithShipping": 0.12,
+    "marketPrice": 0.49,
+    "lowestPriceWithShipping": 0.42,
     "color": [
       "Purple"
     ],
@@ -16868,8 +17556,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 40.69,
-    "lowestPriceWithShipping": 37.11,
+    "marketPrice": 56.22,
+    "lowestPriceWithShipping": 49.95,
     "color": [
       "Purple"
     ],
@@ -16894,8 +17582,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 4.45,
-    "lowestPriceWithShipping": 3.93,
+    "marketPrice": 3.21,
+    "lowestPriceWithShipping": 2.5,
     "color": [
       "Purple"
     ],
@@ -16920,8 +17608,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 6.92,
-    "lowestPriceWithShipping": 7.24,
+    "marketPrice": 10.93,
+    "lowestPriceWithShipping": 9.87,
     "color": [
       "Purple"
     ],
@@ -16946,8 +17634,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 50.65,
-    "lowestPriceWithShipping": 48.48,
+    "marketPrice": 60.91,
+    "lowestPriceWithShipping": 52,
     "color": [
       "Blue"
     ],
@@ -16972,8 +17660,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.23,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.21,
+    "lowestPriceWithShipping": 0.14,
     "color": [
       "Blue",
       "Purple"
@@ -16999,8 +17687,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 112.33,
-    "lowestPriceWithShipping": 107.98,
+    "marketPrice": 162.08,
+    "lowestPriceWithShipping": 150,
     "color": [
       "Blue",
       "Purple"
@@ -17026,8 +17714,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 2.61,
-    "lowestPriceWithShipping": 2.53,
+    "marketPrice": 2.38,
+    "lowestPriceWithShipping": 2.19,
     "color": [
       "Purple"
     ],
@@ -17052,8 +17740,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 26.21,
-    "lowestPriceWithShipping": 26.75,
+    "marketPrice": 37.6,
+    "lowestPriceWithShipping": 31,
     "color": [
       "Purple"
     ],
@@ -17078,8 +17766,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 9.48,
-    "lowestPriceWithShipping": 9.36,
+    "marketPrice": 7.09,
+    "lowestPriceWithShipping": 7.1,
     "color": [
       "Blue"
     ],
@@ -17104,8 +17792,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 29.86,
-    "lowestPriceWithShipping": 28.64,
+    "marketPrice": 27.04,
+    "lowestPriceWithShipping": 19,
     "color": [
       "Blue"
     ],
@@ -17130,8 +17818,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 13.01,
-    "lowestPriceWithShipping": 12,
+    "marketPrice": 13.47,
+    "lowestPriceWithShipping": 12.96,
     "color": [
       "Blue"
     ],
@@ -17149,6 +17837,104 @@
     "productId": 513823
   },
   {
+    "productName": "Kaido (CS 2023 Celebration Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 15.54,
+    "lowestPriceWithShipping": 14.6,
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Special"
+    ],
+    "subtypes": [
+      "Animal Kingdom Pirates",
+      "The Four Emperors"
+    ],
+    "number": "P-010",
+    "productId": 525323
+  },
+  {
+    "productName": "Kaido (CS 2023 Trophy Card) [2nd Place]",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Super Rare"
+    ],
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "Animal Kingdom Pirates",
+      "The Four Emperors"
+    ],
+    "number": "ST04-003",
+    "productId": 525703
+  },
+  {
+    "productName": "Kaido (CS 2023 Trophy Card) [3rd Place]",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Super Rare"
+    ],
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "Animal Kingdom Pirates",
+      "The Four Emperors"
+    ],
+    "number": "ST04-003",
+    "productId": 525702
+  },
+  {
+    "productName": "Kaido (CS 2023 Trophy Card) [Winner]",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Super Rare"
+    ],
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "Animal Kingdom Pirates",
+      "The Four Emperors"
+    ],
+    "number": "ST04-003",
+    "productId": 525704
+  },
+  {
     "productName": "Kaido (Promotion Pack 2022)",
     "setName": [
       "One Piece Promotion Cards"
@@ -17156,8 +17942,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.81,
-    "lowestPriceWithShipping": 1.99,
+    "marketPrice": 2.52,
+    "lowestPriceWithShipping": 2.25,
     "color": [
       "Purple"
     ],
@@ -17183,7 +17969,7 @@
       "Promo"
     ],
     "marketPrice": 3.11,
-    "lowestPriceWithShipping": 2.5,
+    "lowestPriceWithShipping": 2.97,
     "color": [
       "Purple"
     ],
@@ -17208,8 +17994,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 3.33,
-    "lowestPriceWithShipping": 2.78,
+    "marketPrice": 1.16,
+    "lowestPriceWithShipping": 0.92,
     "color": [
       "Purple"
     ],
@@ -17234,8 +18020,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 72.01,
-    "lowestPriceWithShipping": 72,
+    "marketPrice": 68.71,
+    "lowestPriceWithShipping": 59,
     "color": [
       "Purple"
     ],
@@ -17260,8 +18046,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 33.43,
-    "lowestPriceWithShipping": 31.49,
+    "marketPrice": 14.66,
+    "lowestPriceWithShipping": 13.98,
     "color": [
       "Purple"
     ],
@@ -17286,8 +18072,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 2.78,
-    "lowestPriceWithShipping": 1.99,
+    "marketPrice": 2.85,
+    "lowestPriceWithShipping": 3,
     "color": [
       "Purple"
     ],
@@ -17312,8 +18098,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.08,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Purple"
     ],
@@ -17338,8 +18124,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 0.64,
-    "lowestPriceWithShipping": 0.15,
+    "marketPrice": 0.96,
+    "lowestPriceWithShipping": 0.85,
     "color": [
       "Black"
     ],
@@ -17363,8 +18149,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 8.17,
-    "lowestPriceWithShipping": 8.17,
+    "marketPrice": 23.78,
+    "lowestPriceWithShipping": 18.47,
     "color": [
       "Black"
     ],
@@ -17388,8 +18174,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 22.78,
-    "lowestPriceWithShipping": 17.5,
+    "marketPrice": 21.97,
+    "lowestPriceWithShipping": 15.98,
     "color": [
       "Purple"
     ],
@@ -17414,8 +18200,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1,
-    "lowestPriceWithShipping": 0.72,
+    "marketPrice": 0.42,
+    "lowestPriceWithShipping": 0.31,
     "color": [
       "Purple"
     ],
@@ -17440,8 +18226,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.21,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.25,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Black"
     ],
@@ -17465,8 +18251,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 23.14,
-    "lowestPriceWithShipping": 22,
+    "marketPrice": 32.68,
+    "lowestPriceWithShipping": 31.93,
     "color": [
       "Black"
     ],
@@ -17490,8 +18276,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 1.27,
-    "lowestPriceWithShipping": 1.36,
+    "marketPrice": 3.74,
+    "lowestPriceWithShipping": 2,
     "color": [
       "Black"
     ],
@@ -17515,8 +18301,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.55,
-    "lowestPriceWithShipping": 1.5,
+    "marketPrice": 3.67,
+    "lowestPriceWithShipping": 1.92,
     "color": [
       "Black"
     ],
@@ -17566,8 +18352,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.42,
-    "lowestPriceWithShipping": 0.14,
+    "marketPrice": 0.47,
+    "lowestPriceWithShipping": 0.17,
     "color": [
       "Red"
     ],
@@ -17591,8 +18377,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.23,
-    "lowestPriceWithShipping": 0.14,
+    "marketPrice": 0.22,
+    "lowestPriceWithShipping": 0.2,
     "color": [
       "Red"
     ],
@@ -17617,8 +18403,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.37,
-    "lowestPriceWithShipping": 0.35,
+    "marketPrice": 0.4,
+    "lowestPriceWithShipping": 0.39,
     "color": [
       "Red"
     ],
@@ -17643,7 +18429,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.09,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -17669,7 +18455,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -17695,7 +18481,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -17722,8 +18508,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 1.15,
-    "lowestPriceWithShipping": 0.8,
+    "marketPrice": 1.79,
+    "lowestPriceWithShipping": 0.99,
     "color": [
       "Blue"
     ],
@@ -17747,8 +18533,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.5,
-    "lowestPriceWithShipping": 0.3,
+    "marketPrice": 1.52,
+    "lowestPriceWithShipping": 2.84,
     "color": [
       "Green"
     ],
@@ -17773,8 +18559,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.15,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.1,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
     ],
@@ -17798,8 +18584,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.07,
+    "marketPrice": 0.11,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Purple"
     ],
@@ -17823,8 +18609,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.6,
-    "lowestPriceWithShipping": 0.3,
+    "marketPrice": 0.82,
+    "lowestPriceWithShipping": 0.83,
     "color": [
       "Green"
     ],
@@ -17849,8 +18635,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.18,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.24,
+    "lowestPriceWithShipping": 0.19,
     "color": [
       "Green"
     ],
@@ -17868,6 +18654,79 @@
     "productId": 288253
   },
   {
+    "productName": "Killer (CS 2023 Top Players Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "lowestPriceWithShipping": 2599.99,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Kid Pirates",
+      "Supernovas"
+    ],
+    "number": "OP01-039",
+    "productId": 525674
+  },
+  {
+    "productName": "Killer (CS 2023 Top Players Pack) [Finalist]",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Kid Pirates",
+      "Supernovas"
+    ],
+    "number": "OP01-039",
+    "productId": 525675
+  },
+  {
+    "productName": "Killer (CS 2023 Top Players Pack) [Winner]",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Kid Pirates",
+      "Supernovas"
+    ],
+    "number": "OP01-039",
+    "productId": 525676
+  },
+  {
     "productName": "Killer (Promotion Pack 2023)",
     "setName": [
       "One Piece Promotion Cards"
@@ -17875,8 +18734,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.7,
-    "lowestPriceWithShipping": 1.7,
+    "marketPrice": 3.43,
+    "lowestPriceWithShipping": 2.85,
     "color": [
       "Green"
     ],
@@ -17901,8 +18760,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 4.67,
-    "lowestPriceWithShipping": 4.4,
+    "marketPrice": 2.46,
+    "lowestPriceWithShipping": 2.32,
     "color": [
       "Green"
     ],
@@ -17928,7 +18787,7 @@
       "Rare"
     ],
     "marketPrice": 0.06,
-    "lowestPriceWithShipping": 0.01,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Yellow"
     ],
@@ -17952,7 +18811,7 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.16,
+    "marketPrice": 0.19,
     "lowestPriceWithShipping": 0.08,
     "color": [
       "Green"
@@ -17978,8 +18837,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 49.09,
-    "lowestPriceWithShipping": 46.99,
+    "marketPrice": 71.95,
+    "lowestPriceWithShipping": 67.71,
     "color": [
       "Green"
     ],
@@ -18004,8 +18863,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 28.53,
-    "lowestPriceWithShipping": 39,
+    "marketPrice": 40.15,
+    "lowestPriceWithShipping": 36.96,
     "color": [
       "Green"
     ],
@@ -18030,8 +18889,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.4,
-    "lowestPriceWithShipping": 1.22,
+    "marketPrice": 2.38,
+    "lowestPriceWithShipping": 2,
     "color": [
       "Purple"
     ],
@@ -18055,8 +18914,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 4.05,
-    "lowestPriceWithShipping": 3.44,
+    "marketPrice": 6.06,
+    "lowestPriceWithShipping": 19.67,
     "color": [
       "Purple"
     ],
@@ -18080,7 +18939,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Blue"
@@ -18105,7 +18964,7 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.23,
+    "marketPrice": 0.19,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Purple"
@@ -18130,8 +18989,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 62.63,
-    "lowestPriceWithShipping": 63,
+    "marketPrice": 85.04,
+    "lowestPriceWithShipping": 70,
     "color": [
       "Purple"
     ],
@@ -18155,8 +19014,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.28,
-    "lowestPriceWithShipping": 0.97,
+    "marketPrice": 1.74,
+    "lowestPriceWithShipping": 1,
     "color": [
       "Purple"
     ],
@@ -18180,8 +19039,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 13.33,
-    "lowestPriceWithShipping": 13.4,
+    "marketPrice": 25.65,
+    "lowestPriceWithShipping": 19.01,
     "color": [
       "Purple"
     ],
@@ -18205,8 +19064,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.6,
-    "lowestPriceWithShipping": 0.22,
+    "marketPrice": 0.45,
+    "lowestPriceWithShipping": 0.41,
     "color": [
       "Yellow"
     ],
@@ -18231,7 +19090,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
@@ -18257,8 +19116,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 10.04,
-    "lowestPriceWithShipping": 7.74,
+    "marketPrice": 7.9,
+    "lowestPriceWithShipping": 4.93,
     "color": [
       "Red"
     ],
@@ -18282,7 +19141,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -18307,8 +19166,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 110.5,
-    "lowestPriceWithShipping": 100.49,
+    "marketPrice": 160.8,
+    "lowestPriceWithShipping": 158.74,
     "number": null,
     "productId": 485833
   },
@@ -18320,8 +19179,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 1083.35,
-    "lowestPriceWithShipping": 1474.8,
+    "marketPrice": 1656.11,
+    "lowestPriceWithShipping": 1949.97,
     "number": null,
     "productId": 485834
   },
@@ -18333,8 +19192,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 5.51,
-    "lowestPriceWithShipping": 5.53,
+    "marketPrice": 6.6,
+    "lowestPriceWithShipping": 6.89,
     "number": null,
     "productId": 485832
   },
@@ -18346,8 +19205,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 2.3,
-    "lowestPriceWithShipping": 3.94,
+    "marketPrice": 3.86,
+    "lowestPriceWithShipping": 3.64,
     "number": null,
     "productId": 516954
   },
@@ -18359,8 +19218,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 3.61,
-    "lowestPriceWithShipping": 3.97,
+    "marketPrice": 5.08,
+    "lowestPriceWithShipping": 10.94,
     "number": null,
     "productId": 516961
   },
@@ -18372,6 +19231,8 @@
     "rarityName": [
       "None"
     ],
+    "marketPrice": 10.33,
+    "lowestPriceWithShipping": 10.38,
     "number": null,
     "productId": 531777
   },
@@ -18384,7 +19245,7 @@
       "Common"
     ],
     "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.01,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Purple"
     ],
@@ -18410,7 +19271,7 @@
       "Common"
     ],
     "marketPrice": 0.72,
-    "lowestPriceWithShipping": 0.4,
+    "lowestPriceWithShipping": 0.72,
     "color": [
       "Purple"
     ],
@@ -18435,8 +19296,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 2.06,
-    "lowestPriceWithShipping": 1.54,
+    "marketPrice": 1.39,
+    "lowestPriceWithShipping": 0.99,
     "color": [
       "Red"
     ],
@@ -18460,8 +19321,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 19.94,
-    "lowestPriceWithShipping": 19.87,
+    "marketPrice": 21.71,
+    "lowestPriceWithShipping": 21.95,
     "color": [
       "Red"
     ],
@@ -18486,7 +19347,7 @@
       "Common"
     ],
     "marketPrice": 0.45,
-    "lowestPriceWithShipping": 0.1,
+    "lowestPriceWithShipping": 0.09,
     "color": [
       "Black"
     ],
@@ -18510,8 +19371,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.16,
-    "lowestPriceWithShipping": 0.09,
+    "marketPrice": 0.17,
+    "lowestPriceWithShipping": 0.14,
     "color": [
       "Black"
     ],
@@ -18535,8 +19396,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.98,
-    "lowestPriceWithShipping": 0.65,
+    "marketPrice": 0.58,
+    "lowestPriceWithShipping": 0.43,
     "color": [
       "Black"
     ],
@@ -18560,8 +19421,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.11,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.09,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Green"
     ],
@@ -18586,7 +19447,7 @@
       "Common"
     ],
     "marketPrice": 0.33,
-    "lowestPriceWithShipping": 0.18,
+    "lowestPriceWithShipping": 0.2,
     "color": [
       "Green"
     ],
@@ -18610,8 +19471,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.89,
-    "lowestPriceWithShipping": 2,
+    "marketPrice": 2.14,
+    "lowestPriceWithShipping": 1.5,
     "color": [
       "Black"
     ],
@@ -18635,8 +19496,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 65.16,
-    "lowestPriceWithShipping": 79.99,
+    "marketPrice": 80.59,
+    "lowestPriceWithShipping": 199,
     "color": [
       "Black"
     ],
@@ -18660,8 +19521,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 53.25,
-    "lowestPriceWithShipping": 67.99,
+    "marketPrice": 66.53,
+    "lowestPriceWithShipping": 72.98,
     "color": [
       "Black"
     ],
@@ -18709,7 +19570,7 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 2.18,
+    "marketPrice": 2.27,
     "lowestPriceWithShipping": 1.99,
     "color": [
       "Red"
@@ -18735,8 +19596,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 47.87,
-    "lowestPriceWithShipping": 100,
+    "marketPrice": 55.86,
+    "lowestPriceWithShipping": 158.96,
     "color": [
       "Black"
     ],
@@ -18760,8 +19621,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 45.16,
-    "lowestPriceWithShipping": 59.99,
+    "marketPrice": 52.92,
+    "lowestPriceWithShipping": 78.94,
     "color": [
       "Black"
     ],
@@ -18808,8 +19669,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 0.79,
-    "lowestPriceWithShipping": 0.38,
+    "marketPrice": 0.84,
+    "lowestPriceWithShipping": 0.64,
     "color": [
       "Black"
     ],
@@ -18833,8 +19694,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.11,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Purple"
     ],
@@ -18859,7 +19720,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -18885,8 +19746,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.48,
-    "lowestPriceWithShipping": 0.19,
+    "marketPrice": 0.54,
+    "lowestPriceWithShipping": 0.25,
     "color": [
       "Black"
     ],
@@ -18935,8 +19796,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.17,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.11,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Green"
     ],
@@ -18961,8 +19822,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 6.5,
-    "lowestPriceWithShipping": 6.68,
+    "marketPrice": 6.42,
+    "lowestPriceWithShipping": 5,
     "color": [
       "Yellow"
     ],
@@ -18986,8 +19847,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.08,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
     ],
@@ -19011,8 +19872,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 9.4,
-    "lowestPriceWithShipping": 10.3,
+    "marketPrice": 9.85,
+    "lowestPriceWithShipping": 9.02,
     "color": [
       "Yellow"
     ],
@@ -19037,7 +19898,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Yellow"
@@ -19063,8 +19924,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 1.94,
-    "lowestPriceWithShipping": 1.1,
+    "marketPrice": 3.07,
+    "lowestPriceWithShipping": 2.73,
     "color": [
       "Green"
     ],
@@ -19089,7 +19950,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.12,
     "lowestPriceWithShipping": 0.03,
     "color": [
       "Yellow"
@@ -19115,8 +19976,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 2.57,
-    "lowestPriceWithShipping": 2.5,
+    "marketPrice": 2.91,
+    "lowestPriceWithShipping": 2.29,
     "color": [
       "Green"
     ],
@@ -19141,8 +20002,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.22,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.2,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Green"
     ],
@@ -19167,8 +20028,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.39,
-    "lowestPriceWithShipping": 0.98,
+    "marketPrice": 1.24,
+    "lowestPriceWithShipping": 1,
     "color": [
       "Yellow"
     ],
@@ -19193,8 +20054,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 24.9,
-    "lowestPriceWithShipping": 23,
+    "marketPrice": 38.51,
+    "lowestPriceWithShipping": 29.94,
     "color": [
       "Green"
     ],
@@ -19219,8 +20080,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 62.63,
-    "lowestPriceWithShipping": 61.66,
+    "marketPrice": 92.84,
+    "lowestPriceWithShipping": 85.6,
     "color": [
       "Green"
     ],
@@ -19245,7 +20106,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.18,
+    "marketPrice": 0.16,
     "lowestPriceWithShipping": 0.06,
     "color": [
       "Green"
@@ -19271,8 +20132,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.91,
-    "lowestPriceWithShipping": 0.81,
+    "marketPrice": 1.03,
+    "lowestPriceWithShipping": 1,
     "color": [
       "Green"
     ],
@@ -19297,8 +20158,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 4.89,
-    "lowestPriceWithShipping": 5.33,
+    "marketPrice": 8.18,
+    "lowestPriceWithShipping": 7.01,
     "color": [
       "Green"
     ],
@@ -19323,7 +20184,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.62,
+    "marketPrice": 0.6,
     "lowestPriceWithShipping": 0.49,
     "color": [
       "Red"
@@ -19348,7 +20209,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -19373,8 +20234,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 0.71,
-    "lowestPriceWithShipping": 0.47,
+    "marketPrice": 1.02,
+    "lowestPriceWithShipping": 0.85,
     "color": [
       "Green"
     ],
@@ -19399,7 +20260,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
@@ -19424,8 +20285,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 8.39,
-    "lowestPriceWithShipping": 8.4,
+    "marketPrice": 12.61,
+    "lowestPriceWithShipping": 8.99,
     "color": [
       "Green"
     ],
@@ -19450,8 +20311,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.34,
-    "lowestPriceWithShipping": 2.42,
+    "marketPrice": 2.57,
+    "lowestPriceWithShipping": 3.49,
     "color": [
       "Black"
     ],
@@ -19500,8 +20361,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.64,
-    "lowestPriceWithShipping": 0.48,
+    "marketPrice": 0.72,
+    "lowestPriceWithShipping": 0.43,
     "color": [
       "Red"
     ],
@@ -19526,7 +20387,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.04,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -19578,8 +20439,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.62,
-    "lowestPriceWithShipping": 0.4,
+    "marketPrice": 0.52,
+    "lowestPriceWithShipping": 0.43,
     "color": [
       "Green"
     ],
@@ -19604,7 +20465,7 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.11,
+    "marketPrice": 0.1,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -19630,8 +20491,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 25.97,
-    "lowestPriceWithShipping": 26.01,
+    "marketPrice": 48.16,
+    "lowestPriceWithShipping": 34.99,
     "color": null,
     "cardType": [
       "Leader"
@@ -19651,7 +20512,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.13,
+    "marketPrice": 0.12,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Green"
@@ -19678,8 +20539,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 5.63,
-    "lowestPriceWithShipping": 5.25,
+    "marketPrice": 5.81,
+    "lowestPriceWithShipping": 5,
     "color": [
       "Green"
     ],
@@ -19705,8 +20566,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 42.46,
-    "lowestPriceWithShipping": 26.99,
+    "marketPrice": 36.1,
+    "lowestPriceWithShipping": 55,
     "color": [
       "Green"
     ],
@@ -19732,8 +20593,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 26.59,
-    "lowestPriceWithShipping": 18.5,
+    "marketPrice": 19.1,
+    "lowestPriceWithShipping": 18.25,
     "color": [
       "Green"
     ],
@@ -19784,8 +20645,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 29.41,
-    "lowestPriceWithShipping": 29.94,
+    "marketPrice": 30.92,
+    "lowestPriceWithShipping": 59.94,
     "color": [
       "Green"
     ],
@@ -19811,8 +20672,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 26.11,
-    "lowestPriceWithShipping": 19.83,
+    "marketPrice": 19.83,
+    "lowestPriceWithShipping": 18,
     "color": [
       "Green"
     ],
@@ -19863,8 +20724,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.14,
-    "lowestPriceWithShipping": 0.09,
+    "marketPrice": 0.12,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Purple"
     ],
@@ -19889,8 +20750,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.09,
-    "lowestPriceWithShipping": 0.98,
+    "marketPrice": 1.05,
+    "lowestPriceWithShipping": 0.5,
     "color": [
       "Purple"
     ],
@@ -19915,8 +20776,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.07,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Purple"
     ],
@@ -19941,8 +20802,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.04,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
     ],
@@ -19967,8 +20828,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.04,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
     ],
@@ -19992,8 +20853,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.11,
-    "lowestPriceWithShipping": 2.86,
+    "marketPrice": 2.58,
+    "lowestPriceWithShipping": 1,
     "color": [
       "Green"
     ],
@@ -20017,8 +20878,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 18.72,
-    "lowestPriceWithShipping": 18.77,
+    "marketPrice": 18.05,
+    "lowestPriceWithShipping": 18.98,
     "color": [
       "Black"
     ],
@@ -20042,8 +20903,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 75.83,
-    "lowestPriceWithShipping": 75.5,
+    "marketPrice": 80.97,
+    "lowestPriceWithShipping": 75.8,
     "color": [
       "Black"
     ],
@@ -20067,8 +20928,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 24.66,
-    "lowestPriceWithShipping": 24.98,
+    "marketPrice": 22.68,
+    "lowestPriceWithShipping": 21.98,
     "color": [
       "Black"
     ],
@@ -20092,8 +20953,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 55.06,
-    "lowestPriceWithShipping": 49.94,
+    "marketPrice": 45.34,
+    "lowestPriceWithShipping": 42.95,
     "color": [
       "Black"
     ],
@@ -20117,8 +20978,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 510.3,
-    "lowestPriceWithShipping": 1495,
+    "marketPrice": 614.94,
+    "lowestPriceWithShipping": 1297.96,
     "color": [
       "Black"
     ],
@@ -20142,8 +21003,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.14,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.13,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Purple"
     ],
@@ -20167,8 +21028,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.15,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.13,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Black"
     ],
@@ -20192,8 +21053,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 10.28,
-    "lowestPriceWithShipping": 10.38,
+    "marketPrice": 10.97,
+    "lowestPriceWithShipping": 8.79,
     "color": [
       "Black"
     ],
@@ -20217,8 +21078,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.08,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.11,
+    "lowestPriceWithShipping": 0.08,
     "color": [
       "Black"
     ],
@@ -20242,7 +21103,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -20265,8 +21126,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.11,
-    "lowestPriceWithShipping": 1,
+    "marketPrice": 1.1,
+    "lowestPriceWithShipping": 1.01,
     "color": [
       "Green"
     ],
@@ -20288,7 +21149,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.09,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -20313,8 +21174,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 2.04,
-    "lowestPriceWithShipping": 1.75,
+    "marketPrice": 1.97,
+    "lowestPriceWithShipping": 1.5,
     "color": [
       "Green"
     ],
@@ -20338,8 +21199,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.75,
-    "lowestPriceWithShipping": 1.24,
+    "marketPrice": 0.94,
+    "lowestPriceWithShipping": 0.83,
     "color": [
       "Purple"
     ],
@@ -20361,8 +21222,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.87,
-    "lowestPriceWithShipping": 2.15,
+    "marketPrice": 1.68,
+    "lowestPriceWithShipping": 1,
     "color": [
       "Purple"
     ],
@@ -20384,8 +21245,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 6.62,
-    "lowestPriceWithShipping": 6.99,
+    "marketPrice": 8.13,
+    "lowestPriceWithShipping": 7,
     "color": [
       "Black"
     ],
@@ -20410,8 +21271,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.12,
-    "lowestPriceWithShipping": 0.06,
+    "marketPrice": 0.11,
+    "lowestPriceWithShipping": 0.07,
     "color": [
       "Black"
     ],
@@ -20436,8 +21297,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 10,
-    "lowestPriceWithShipping": 5.98,
+    "marketPrice": 4.94,
+    "lowestPriceWithShipping": 7.98,
     "color": [
       "Blue"
     ],
@@ -20460,8 +21321,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.07,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Blue"
     ],
@@ -20484,8 +21345,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.33,
-    "lowestPriceWithShipping": 2.83,
+    "marketPrice": 2.48,
+    "lowestPriceWithShipping": 1.48,
     "color": [
       "Yellow"
     ],
@@ -20509,8 +21370,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.07,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
     ],
@@ -20534,8 +21395,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.43,
-    "lowestPriceWithShipping": 1.39,
+    "marketPrice": 1.49,
+    "lowestPriceWithShipping": 1.7,
     "color": [
       "Red"
     ],
@@ -20559,8 +21420,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.09,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Red"
     ],
@@ -20584,8 +21445,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.27,
-    "lowestPriceWithShipping": 0.2,
+    "marketPrice": 0.28,
+    "lowestPriceWithShipping": 0.17,
     "color": [
       "Red"
     ],
@@ -20610,8 +21471,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.23,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.24,
+    "lowestPriceWithShipping": 0.17,
     "color": [
       "Purple"
     ],
@@ -20634,8 +21495,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.28,
-    "lowestPriceWithShipping": 0.11,
+    "marketPrice": 0.38,
+    "lowestPriceWithShipping": 0.23,
     "color": [
       "Purple"
     ],
@@ -20659,8 +21520,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 24.72,
-    "lowestPriceWithShipping": 21.99,
+    "marketPrice": 30.84,
+    "lowestPriceWithShipping": 26,
     "color": [
       "Purple"
     ],
@@ -20684,8 +21545,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.54,
-    "lowestPriceWithShipping": 1.15,
+    "marketPrice": 3.93,
+    "lowestPriceWithShipping": 2.08,
     "color": [
       "Purple"
     ],
@@ -20761,8 +21622,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 10.27,
-    "lowestPriceWithShipping": 9.95,
+    "marketPrice": 14.45,
+    "lowestPriceWithShipping": 15,
     "color": [
       "Blue"
     ],
@@ -20785,8 +21646,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 8.76,
-    "lowestPriceWithShipping": 9.49,
+    "marketPrice": 12.72,
+    "lowestPriceWithShipping": 14,
     "color": [
       "Blue"
     ],
@@ -20834,8 +21695,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 2.54,
-    "lowestPriceWithShipping": 8.5,
+    "marketPrice": 3.96,
+    "lowestPriceWithShipping": 5.95,
     "color": [
       "Green"
     ],
@@ -20859,7 +21720,7 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.17,
+    "marketPrice": 0.2,
     "lowestPriceWithShipping": 0.1,
     "color": [
       "Purple"
@@ -20884,8 +21745,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 70.26,
-    "lowestPriceWithShipping": 64.95,
+    "marketPrice": 94.86,
+    "lowestPriceWithShipping": 82.99,
     "color": [
       "Purple"
     ],
@@ -20909,8 +21770,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 13.99,
-    "lowestPriceWithShipping": 13.99,
+    "marketPrice": 9.85,
+    "lowestPriceWithShipping": 10.73,
     "color": [
       "Purple"
     ],
@@ -20934,8 +21795,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 37.88,
-    "lowestPriceWithShipping": 35,
+    "marketPrice": 40.03,
+    "lowestPriceWithShipping": 29.81,
     "color": [
       "Purple"
     ],
@@ -20959,8 +21820,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 49.45,
-    "lowestPriceWithShipping": 50.01,
+    "marketPrice": 49.54,
+    "lowestPriceWithShipping": 43.95,
     "color": [
       "Purple"
     ],
@@ -20984,8 +21845,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 8.92,
-    "lowestPriceWithShipping": 7.23,
+    "marketPrice": 7.2,
+    "lowestPriceWithShipping": 5.9,
     "color": [
       "Red"
     ],
@@ -21009,7 +21870,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.13,
+    "marketPrice": 0.17,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Red"
@@ -21029,38 +21890,13 @@
   {
     "productName": "Makino",
     "setName": [
-      "Paramount War"
-    ],
-    "rarityName": [
-      "Uncommon"
-    ],
-    "marketPrice": 1.43,
-    "lowestPriceWithShipping": 0.73,
-    "color": [
-      "Red"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Wisdom"
-    ],
-    "subtypes": [
-      "Windmill Village"
-    ],
-    "number": "OP02-015",
-    "productId": 486335
-  },
-  {
-    "productName": "Makino",
-    "setName": [
       "Starter Deck 8 MonkeyDLuffy"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.2,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.17,
+    "lowestPriceWithShipping": 0.07,
     "color": [
       "Black"
     ],
@@ -21079,13 +21915,38 @@
   {
     "productName": "Makino",
     "setName": [
+      "Paramount War"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "marketPrice": 1.3,
+    "lowestPriceWithShipping": 1.2,
+    "color": [
+      "Red"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Wisdom"
+    ],
+    "subtypes": [
+      "Windmill Village"
+    ],
+    "number": "OP02-015",
+    "productId": 486335
+  },
+  {
+    "productName": "Makino",
+    "setName": [
       "Paramount War Pre Release Cards"
     ],
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 10.21,
-    "lowestPriceWithShipping": 9.9,
+    "marketPrice": 9.69,
+    "lowestPriceWithShipping": 9,
     "color": [
       "Red"
     ],
@@ -21102,6 +21963,29 @@
     "productId": 486739
   },
   {
+    "productName": "Makino (Japanese 1st Anniversary Set)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "color": [
+      "Red"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Wisdom"
+    ],
+    "subtypes": [
+      "Windmill Village"
+    ],
+    "number": "OP02-015",
+    "productId": 536169
+  },
+  {
     "productName": "Mansherry",
     "setName": [
       "Awakening of the New Era"
@@ -21109,8 +21993,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.41,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.24,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Black"
     ],
@@ -21135,8 +22019,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 15.84,
-    "lowestPriceWithShipping": 15.95,
+    "marketPrice": 16.07,
+    "lowestPriceWithShipping": 15.9,
     "color": [
       "Black"
     ],
@@ -21161,8 +22045,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 5.68,
-    "lowestPriceWithShipping": 5.99,
+    "marketPrice": 7.73,
+    "lowestPriceWithShipping": 6.9,
     "color": [
       "Red"
     ],
@@ -21186,8 +22070,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 1.26,
-    "lowestPriceWithShipping": 0.84,
+    "marketPrice": 1.06,
+    "lowestPriceWithShipping": 0.73,
     "color": [
       "Red"
     ],
@@ -21236,8 +22120,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 36.74,
-    "lowestPriceWithShipping": 29,
+    "marketPrice": 37.71,
+    "lowestPriceWithShipping": 33,
     "color": [
       "Red"
     ],
@@ -21261,8 +22145,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 23.62,
-    "lowestPriceWithShipping": 20.8,
+    "marketPrice": 31.59,
+    "lowestPriceWithShipping": 29.8,
     "color": [
       "Red"
     ],
@@ -21286,8 +22170,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 541.33,
-    "lowestPriceWithShipping": 559.99,
+    "marketPrice": 673.71,
+    "lowestPriceWithShipping": 1099,
     "color": [
       "Red"
     ],
@@ -21304,6 +22188,29 @@
     "productId": 514046
   },
   {
+    "productName": "Marco (Japanese 1st Anniversary Set)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Super Rare"
+    ],
+    "color": [
+      "Red"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Special"
+    ],
+    "subtypes": [
+      "Whitebeard Pirates"
+    ],
+    "number": "OP03-013",
+    "productId": 536168
+  },
+  {
     "productName": "Marco (Promotion Pack 2023)",
     "setName": [
       "One Piece Promotion Cards"
@@ -21311,8 +22218,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 2.61,
-    "lowestPriceWithShipping": 2.68,
+    "marketPrice": 4.11,
+    "lowestPriceWithShipping": 3.69,
     "color": [
       "Red"
     ],
@@ -21336,8 +22243,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 275.91,
-    "lowestPriceWithShipping": 344.99,
+    "marketPrice": 300.65,
+    "lowestPriceWithShipping": 400.98,
     "color": [
       "Red"
     ],
@@ -21361,8 +22268,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.54,
-    "lowestPriceWithShipping": 0.15,
+    "marketPrice": 0.6,
+    "lowestPriceWithShipping": 0.4,
     "color": [
       "Blue"
     ],
@@ -21388,7 +22295,7 @@
       "Common"
     ],
     "marketPrice": 0.25,
-    "lowestPriceWithShipping": 0.11,
+    "lowestPriceWithShipping": 0.15,
     "color": [
       "Blue"
     ],
@@ -21413,7 +22320,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.12,
+    "marketPrice": 0.16,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -21438,8 +22345,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 25.36,
-    "lowestPriceWithShipping": 18.88,
+    "marketPrice": 22.94,
+    "lowestPriceWithShipping": 32,
     "color": [
       "Blue"
     ],
@@ -21464,8 +22371,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 8.91,
-    "lowestPriceWithShipping": 8,
+    "marketPrice": 16.44,
+    "lowestPriceWithShipping": 21.98,
     "color": [
       "Blue"
     ],
@@ -21514,8 +22421,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 28.68,
-    "lowestPriceWithShipping": 22.73,
+    "marketPrice": 27.07,
+    "lowestPriceWithShipping": 71,
     "color": [
       "Blue"
     ],
@@ -21540,8 +22447,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 8.85,
-    "lowestPriceWithShipping": 19.99,
+    "marketPrice": 13.66,
+    "lowestPriceWithShipping": 49.99,
     "color": [
       "Blue"
     ],
@@ -21590,8 +22497,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.05,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
     ],
@@ -21613,8 +22520,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.84,
-    "lowestPriceWithShipping": 3.45,
+    "marketPrice": 2.8,
+    "lowestPriceWithShipping": 1.92,
     "color": [
       "Black"
     ],
@@ -21636,7 +22543,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.13,
+    "marketPrice": 0.14,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -21661,8 +22568,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 4.69,
-    "lowestPriceWithShipping": 5,
+    "marketPrice": 9.28,
+    "lowestPriceWithShipping": 6,
     "color": [
       "Red"
     ],
@@ -21686,8 +22593,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.06,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
     ],
@@ -21711,7 +22618,8 @@
     "rarityName": [
       "Common"
     ],
-    "lowestPriceWithShipping": 3.669,
+    "marketPrice": 2.88,
+    "lowestPriceWithShipping": 2.18,
     "color": [
       "Blue"
     ],
@@ -21735,8 +22643,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 111.02,
-    "lowestPriceWithShipping": 111.29,
+    "marketPrice": 179.99,
+    "lowestPriceWithShipping": 179.95,
     "number": null,
     "productId": 521161
   },
@@ -21748,8 +22656,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 1197.88,
-    "lowestPriceWithShipping": 1197.88,
+    "marketPrice": 1404.72,
+    "lowestPriceWithShipping": 2149.95,
     "number": null,
     "productId": 521162
   },
@@ -21761,8 +22669,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 4.98,
-    "lowestPriceWithShipping": 4.98,
+    "marketPrice": 6.06,
+    "lowestPriceWithShipping": 7.99,
     "number": null,
     "productId": 521160
   },
@@ -21774,8 +22682,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.48,
-    "lowestPriceWithShipping": 0.3,
+    "marketPrice": 0.44,
+    "lowestPriceWithShipping": 0.29,
     "color": [
       "Blue"
     ],
@@ -21799,7 +22707,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
@@ -21824,8 +22732,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.2,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.22,
+    "lowestPriceWithShipping": 0.12,
     "color": [
       "Black"
     ],
@@ -21847,8 +22755,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1,
-    "lowestPriceWithShipping": 1,
+    "marketPrice": 1.01,
+    "lowestPriceWithShipping": 0.75,
     "color": [
       "Purple"
     ],
@@ -21873,8 +22781,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.2,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.22,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Purple"
     ],
@@ -21899,8 +22807,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 3.35,
-    "lowestPriceWithShipping": 7.98,
+    "marketPrice": 5,
+    "lowestPriceWithShipping": 3.97,
     "color": [
       "Purple"
     ],
@@ -21925,7 +22833,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -21951,8 +22859,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.82,
-    "lowestPriceWithShipping": 1.15,
+    "marketPrice": 1.68,
+    "lowestPriceWithShipping": 1.22,
     "color": [
       "Purple"
     ],
@@ -21977,8 +22885,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 39.95,
-    "lowestPriceWithShipping": 35.99,
+    "marketPrice": 39.75,
+    "lowestPriceWithShipping": 60,
     "color": [
       "Purple"
     ],
@@ -22003,8 +22911,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 23.5,
-    "lowestPriceWithShipping": 20.99,
+    "marketPrice": 22.29,
+    "lowestPriceWithShipping": 26.26,
     "color": [
       "Purple"
     ],
@@ -22053,8 +22961,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 41.27,
-    "lowestPriceWithShipping": 40.48,
+    "marketPrice": 41.17,
+    "lowestPriceWithShipping": 74.95,
     "color": [
       "Purple"
     ],
@@ -22079,8 +22987,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 23.16,
-    "lowestPriceWithShipping": 17,
+    "marketPrice": 22.18,
+    "lowestPriceWithShipping": 20,
     "color": [
       "Purple"
     ],
@@ -22129,8 +23037,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.16,
-    "lowestPriceWithShipping": 0.06,
+    "marketPrice": 0.14,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Purple"
     ],
@@ -22155,8 +23063,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 3.66,
-    "lowestPriceWithShipping": 2.89,
+    "marketPrice": 3.45,
+    "lowestPriceWithShipping": 3,
     "color": [
       "Purple"
     ],
@@ -22181,8 +23089,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.27,
-    "lowestPriceWithShipping": 1.39,
+    "marketPrice": 2.67,
+    "lowestPriceWithShipping": 6.5,
     "color": [
       "Purple"
     ],
@@ -22207,8 +23115,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.06,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Purple"
     ],
@@ -22233,7 +23141,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
@@ -22258,8 +23166,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 24.72,
-    "lowestPriceWithShipping": 21.98,
+    "marketPrice": 22.23,
+    "lowestPriceWithShipping": 45,
     "color": [
       "Purple"
     ],
@@ -22283,7 +23191,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.26,
+    "marketPrice": 0.24,
     "lowestPriceWithShipping": 0.19,
     "color": [
       "Purple"
@@ -22308,8 +23216,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.1,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
     ],
@@ -22333,8 +23241,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.87,
-    "lowestPriceWithShipping": 0.65,
+    "marketPrice": 0.85,
+    "lowestPriceWithShipping": 0.88,
     "color": [
       "Purple"
     ],
@@ -22358,8 +23266,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.43,
-    "lowestPriceWithShipping": 0.4,
+    "marketPrice": 0.48,
+    "lowestPriceWithShipping": 0.44,
     "color": [
       "Purple"
     ],
@@ -22383,7 +23291,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -22408,7 +23316,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.1,
+    "marketPrice": 0.11,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -22433,8 +23341,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.22,
-    "lowestPriceWithShipping": 6.25,
+    "marketPrice": 9.05,
+    "lowestPriceWithShipping": 39.99,
     "color": [
       "Red"
     ],
@@ -22456,7 +23364,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.11,
+    "marketPrice": 0.13,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -22479,7 +23387,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.04,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
@@ -22504,8 +23412,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.13,
-    "lowestPriceWithShipping": 0.99,
+    "marketPrice": 1.26,
+    "lowestPriceWithShipping": 1.23,
     "color": [
       "Blue"
     ],
@@ -22529,7 +23437,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.03,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
@@ -22555,7 +23463,7 @@
       "Common"
     ],
     "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.03,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Black"
     ],
@@ -22579,7 +23487,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -22605,7 +23513,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.64,
+    "marketPrice": 0.65,
     "lowestPriceWithShipping": 0.48,
     "color": [
       "Green"
@@ -22631,7 +23539,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.09,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Blue"
@@ -22657,8 +23565,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.11,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Green"
     ],
@@ -22682,8 +23590,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 17.99,
-    "lowestPriceWithShipping": 13.91,
+    "marketPrice": 15,
+    "lowestPriceWithShipping": 16.24,
     "color": [
       "Green"
     ],
@@ -22707,8 +23615,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.39,
-    "lowestPriceWithShipping": 1.39,
+    "marketPrice": 1.45,
+    "lowestPriceWithShipping": 1.45,
     "color": [
       "Red"
     ],
@@ -22732,8 +23640,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 6.65,
-    "lowestPriceWithShipping": 6.99,
+    "marketPrice": 9.56,
+    "lowestPriceWithShipping": 11.84,
     "color": [
       "Blue"
     ],
@@ -22752,12 +23660,37 @@
   {
     "productName": "Monkey.D.Garp",
     "setName": [
+      "Starter Deck 8 MonkeyDLuffy"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 0.09,
+    "lowestPriceWithShipping": 0.04,
+    "color": [
+      "Black"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "Navy"
+    ],
+    "number": "ST08-010",
+    "productId": 503241
+  },
+  {
+    "productName": "Monkey.D.Garp",
+    "setName": [
       "Awakening of the New Era"
     ],
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.14,
+    "marketPrice": 0.09,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Blue"
@@ -22777,38 +23710,13 @@
   {
     "productName": "Monkey.D.Garp",
     "setName": [
-      "Starter Deck 8 MonkeyDLuffy"
-    ],
-    "rarityName": [
-      "Common"
-    ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.07,
-    "color": [
-      "Black"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Strike"
-    ],
-    "subtypes": [
-      "Navy"
-    ],
-    "number": "ST08-010",
-    "productId": 503241
-  },
-  {
-    "productName": "Monkey.D.Garp",
-    "setName": [
       "Starter Deck 6 Absolute Justice"
     ],
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 2.24,
-    "lowestPriceWithShipping": 1.53,
+    "marketPrice": 1.6,
+    "lowestPriceWithShipping": 1.37,
     "color": [
       "Black"
     ],
@@ -22832,8 +23740,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.08,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Red"
     ],
@@ -22857,8 +23765,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.17,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.18,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Red",
       "Black"
@@ -22883,8 +23791,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 73.56,
-    "lowestPriceWithShipping": 70.48,
+    "marketPrice": 113.71,
+    "lowestPriceWithShipping": 100,
     "color": [
       "Red",
       "Black"
@@ -22909,7 +23817,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.45,
+    "marketPrice": 0.31,
     "lowestPriceWithShipping": 0.2,
     "color": [
       "Black"
@@ -22934,8 +23842,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 24.03,
-    "lowestPriceWithShipping": 20.98,
+    "marketPrice": 22.63,
+    "lowestPriceWithShipping": 19.51,
     "color": [
       "Black"
     ],
@@ -22959,8 +23867,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 7.98,
-    "lowestPriceWithShipping": 6.01,
+    "marketPrice": 20.33,
+    "lowestPriceWithShipping": 25.48,
     "color": [
       "Blue"
     ],
@@ -22984,8 +23892,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 3.56,
-    "lowestPriceWithShipping": 3.5,
+    "marketPrice": 4.87,
+    "lowestPriceWithShipping": 5.73,
     "color": [
       "Red"
     ],
@@ -23010,8 +23918,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.16,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.14,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Purple"
     ],
@@ -23036,7 +23944,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.1,
+    "marketPrice": 0.09,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Yellow"
@@ -23062,8 +23970,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 8.59,
-    "lowestPriceWithShipping": 8.01,
+    "marketPrice": 16.68,
+    "lowestPriceWithShipping": 9.69,
     "color": [
       "Red"
     ],
@@ -23088,8 +23996,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 6.7,
-    "lowestPriceWithShipping": 7.97,
+    "marketPrice": 8.27,
+    "lowestPriceWithShipping": 7.75,
     "color": [
       "Red"
     ],
@@ -23114,8 +24022,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 27.25,
-    "lowestPriceWithShipping": 19.85,
+    "marketPrice": 46.18,
+    "lowestPriceWithShipping": 29.99,
     "color": [
       "Red"
     ],
@@ -23140,7 +24048,7 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.07,
+    "marketPrice": 1.2,
     "lowestPriceWithShipping": 1,
     "color": [
       "Red"
@@ -23166,8 +24074,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 12.21,
-    "lowestPriceWithShipping": 12.61,
+    "marketPrice": 34.78,
+    "lowestPriceWithShipping": 21.66,
     "color": [
       "Red"
     ],
@@ -23192,8 +24100,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 4294.87,
-    "lowestPriceWithShipping": 7495,
+    "marketPrice": 4985,
+    "lowestPriceWithShipping": 8930,
     "color": [
       "Red"
     ],
@@ -23218,8 +24126,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.5,
-    "lowestPriceWithShipping": 0.35,
+    "marketPrice": 0.78,
+    "lowestPriceWithShipping": 0.4,
     "color": [
       "Red"
     ],
@@ -23244,8 +24152,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 1.85,
-    "lowestPriceWithShipping": 1.4,
+    "marketPrice": 1.62,
+    "lowestPriceWithShipping": 1.27,
     "color": [
       "Black"
     ],
@@ -23269,8 +24177,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 104.19,
-    "lowestPriceWithShipping": 99.99,
+    "marketPrice": 173.45,
+    "lowestPriceWithShipping": 165,
     "color": [
       "Red"
     ],
@@ -23295,7 +24203,7 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 1.29,
+    "marketPrice": 1.34,
     "lowestPriceWithShipping": 0.95,
     "color": [
       "Purple",
@@ -23321,8 +24229,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.23,
-    "lowestPriceWithShipping": 0.15,
+    "marketPrice": 0.26,
+    "lowestPriceWithShipping": 0.18,
     "color": [
       "Green",
       "Red"
@@ -23348,8 +24256,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 165.74,
-    "lowestPriceWithShipping": 285.01,
+    "marketPrice": 303.96,
+    "lowestPriceWithShipping": 259,
     "color": [
       "Green",
       "Red"
@@ -23375,8 +24283,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.23,
-    "lowestPriceWithShipping": 0.99,
+    "marketPrice": 1.46,
+    "lowestPriceWithShipping": 1.18,
     "color": [
       "Red"
     ],
@@ -23393,6 +24301,58 @@
     "productId": 525049
   },
   {
+    "productName": "Monkey.D.Luffy (006) (CS 2023 Celebration Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 48.34,
+    "lowestPriceWithShipping": 29.98,
+    "color": [
+      "Red"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "Straw Hat Crew",
+      "Supernovas"
+    ],
+    "number": "P-006",
+    "productId": 525310
+  },
+  {
+    "productName": "Monkey.D.Luffy (007) (CS 2023 Celebration Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 21.73,
+    "lowestPriceWithShipping": 11.9,
+    "color": [
+      "Red"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "Straw Hat Crew",
+      "Supernovas"
+    ],
+    "number": "P-007",
+    "productId": 525315
+  },
+  {
     "productName": "Monkey.D.Luffy (011)",
     "setName": [
       "Starter Deck 8 MonkeyDLuffy"
@@ -23401,7 +24361,7 @@
       "Common"
     ],
     "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.02,
+    "lowestPriceWithShipping": 0.06,
     "color": [
       "Black"
     ],
@@ -23425,8 +24385,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 18.28,
-    "lowestPriceWithShipping": 15,
+    "marketPrice": 19.72,
+    "lowestPriceWithShipping": 13.49,
     "color": [
       "Red"
     ],
@@ -23451,8 +24411,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 10,
-    "lowestPriceWithShipping": 9,
+    "marketPrice": 7.42,
+    "lowestPriceWithShipping": 7,
     "color": [
       "Red"
     ],
@@ -23477,8 +24437,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 20.89,
-    "lowestPriceWithShipping": 18.94,
+    "marketPrice": 21.81,
+    "lowestPriceWithShipping": 20.65,
     "color": [
       "Red"
     ],
@@ -23503,8 +24463,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1855.29,
-    "lowestPriceWithShipping": 2000,
+    "marketPrice": 2021.88,
+    "lowestPriceWithShipping": 1800,
     "color": [
       "Red"
     ],
@@ -23529,7 +24489,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -23555,8 +24515,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 2.37,
-    "lowestPriceWithShipping": 1.89,
+    "marketPrice": 2.61,
+    "lowestPriceWithShipping": 2.39,
     "color": [
       "Red"
     ],
@@ -23581,8 +24541,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 35.65,
-    "lowestPriceWithShipping": 36.5,
+    "marketPrice": 70.78,
+    "lowestPriceWithShipping": 53,
     "color": [
       "Red"
     ],
@@ -23607,8 +24567,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 3.08,
-    "lowestPriceWithShipping": 2.86,
+    "marketPrice": 4.08,
+    "lowestPriceWithShipping": 3.97,
     "color": [
       "Green"
     ],
@@ -23632,8 +24592,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 8.47,
-    "lowestPriceWithShipping": 8.38,
+    "marketPrice": 7.01,
+    "lowestPriceWithShipping": 7.19,
     "color": [
       "Purple"
     ],
@@ -23658,8 +24618,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 1.09,
-    "lowestPriceWithShipping": 0.9,
+    "marketPrice": 0.56,
+    "lowestPriceWithShipping": 0.4,
     "color": [
       "Green"
     ],
@@ -23685,8 +24645,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 328.52,
-    "lowestPriceWithShipping": 337.73,
+    "marketPrice": 500.06,
+    "lowestPriceWithShipping": 475.97,
     "color": [
       "Purple"
     ],
@@ -23711,8 +24671,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 31.44,
-    "lowestPriceWithShipping": 30.98,
+    "marketPrice": 61.98,
+    "lowestPriceWithShipping": 60,
     "color": [
       "Green"
     ],
@@ -23723,12 +24683,37 @@
       "Strike"
     ],
     "subtypes": [
-      "Film",
       "Straw Hat Crew",
       "Supernovas"
     ],
     "number": "OP02-041",
     "productId": 482337
+  },
+  {
+    "productName": "Monkey.D.Luffy (041) (BANDAI CARD GAMES Fest 23-24 World Tour)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 94.47,
+    "lowestPriceWithShipping": 90,
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "Straw Hat Crew",
+      "The Four Emperors"
+    ],
+    "number": "P-041",
+    "productId": 532752
   },
   {
     "productName": "Monkey.D.Luffy (047) (Sealed Battle Kit Vol. 1)",
@@ -23738,8 +24723,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 47.5,
-    "lowestPriceWithShipping": 47.64,
+    "marketPrice": 60.98,
+    "lowestPriceWithShipping": 57.99,
     "color": [
       "Blue"
     ],
@@ -23763,8 +24748,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 55.23,
-    "lowestPriceWithShipping": 54.01,
+    "marketPrice": 65.98,
+    "lowestPriceWithShipping": 49.96,
     "color": [
       "Blue"
     ],
@@ -23788,8 +24773,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.08,
+    "marketPrice": 0.16,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Purple"
     ],
@@ -23813,8 +24798,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 106.26,
-    "lowestPriceWithShipping": 100,
+    "marketPrice": 95.66,
+    "lowestPriceWithShipping": 86.96,
     "color": [
       "Purple"
     ],
@@ -23838,8 +24823,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.72,
-    "lowestPriceWithShipping": 1.28,
+    "marketPrice": 1.93,
+    "lowestPriceWithShipping": 1.9,
     "color": [
       "Blue"
     ],
@@ -23864,8 +24849,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 23.31,
-    "lowestPriceWithShipping": 28,
+    "marketPrice": 39.38,
+    "lowestPriceWithShipping": 23.94,
     "color": [
       "Blue"
     ],
@@ -23890,8 +24875,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 2.05,
-    "lowestPriceWithShipping": 1.18,
+    "marketPrice": 1.07,
+    "lowestPriceWithShipping": 0.89,
     "color": [
       "Black"
     ],
@@ -23916,8 +24901,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 17.41,
-    "lowestPriceWithShipping": 17.13,
+    "marketPrice": 22.55,
+    "lowestPriceWithShipping": 19.65,
     "color": [
       "Black"
     ],
@@ -23942,8 +24927,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 16.99,
-    "lowestPriceWithShipping": 17.69,
+    "marketPrice": 14.84,
+    "lowestPriceWithShipping": 13.66,
     "color": [
       "Purple"
     ],
@@ -23968,8 +24953,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 59.79,
-    "lowestPriceWithShipping": 61.99,
+    "marketPrice": 62.6,
+    "lowestPriceWithShipping": 60.81,
     "color": [
       "Purple"
     ],
@@ -23994,8 +24979,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 1931.29,
-    "lowestPriceWithShipping": 2745,
+    "marketPrice": 3176.67,
+    "lowestPriceWithShipping": 3799,
     "color": [
       "Purple"
     ],
@@ -24020,8 +25005,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 3.69,
-    "lowestPriceWithShipping": 3.46,
+    "marketPrice": 10.31,
+    "lowestPriceWithShipping": 12.7,
     "color": [
       "Red"
     ],
@@ -24046,8 +25031,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 8.55,
-    "lowestPriceWithShipping": 7.98,
+    "marketPrice": 7.59,
+    "lowestPriceWithShipping": 5.46,
     "color": [
       "Green"
     ],
@@ -24064,6 +25049,31 @@
     "productId": 498786
   },
   {
+    "productName": "Monkey.D.Luffy (CS 2023 Event Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 80.95,
+    "lowestPriceWithShipping": 70.95,
+    "color": [
+      "Blue"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "Straw Hat Crew"
+    ],
+    "number": "P-033",
+    "productId": 525304
+  },
+  {
     "productName": "Monkey.D.Luffy (Dash Pack)",
     "setName": [
       "Kingdoms of Intrigue"
@@ -24071,8 +25081,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.8,
-    "lowestPriceWithShipping": 0.43,
+    "marketPrice": 2.02,
+    "lowestPriceWithShipping": 1.98,
     "color": [
       "Purple"
     ],
@@ -24097,8 +25107,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 20.45,
-    "lowestPriceWithShipping": 19.99,
+    "marketPrice": 27.52,
+    "lowestPriceWithShipping": 23.99,
     "color": [
       "Blue"
     ],
@@ -24122,8 +25132,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 5.89,
-    "lowestPriceWithShipping": 4.25,
+    "marketPrice": 4.81,
+    "lowestPriceWithShipping": 3.99,
     "color": [
       "Green"
     ],
@@ -24147,8 +25157,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 3.12,
-    "lowestPriceWithShipping": 2.75,
+    "marketPrice": 3.15,
+    "lowestPriceWithShipping": 2.49,
     "color": [
       "Red"
     ],
@@ -24173,8 +25183,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 6.72,
-    "lowestPriceWithShipping": 3.94,
+    "marketPrice": 5.44,
+    "lowestPriceWithShipping": 3.79,
     "color": [
       "Purple"
     ],
@@ -24199,8 +25209,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 5.61,
-    "lowestPriceWithShipping": 6.94,
+    "marketPrice": 7.73,
+    "lowestPriceWithShipping": 6.4,
     "color": [
       "Blue",
       "Green",
@@ -24229,8 +25239,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 11.99,
-    "lowestPriceWithShipping": 12.13,
+    "marketPrice": 14.81,
+    "lowestPriceWithShipping": 13.63,
     "color": [
       "Blue",
       "Green",
@@ -24259,8 +25269,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 3.32,
-    "lowestPriceWithShipping": 3.4,
+    "marketPrice": 3.09,
+    "lowestPriceWithShipping": 3,
     "color": [
       "Red"
     ],
@@ -24286,8 +25296,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 2.42,
-    "lowestPriceWithShipping": 2.2,
+    "marketPrice": 3.92,
+    "lowestPriceWithShipping": 3.88,
     "color": [
       "Black"
     ],
@@ -24311,8 +25321,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 4.8,
-    "lowestPriceWithShipping": 5,
+    "marketPrice": 1.98,
+    "lowestPriceWithShipping": 1.77,
     "color": [
       "Yellow"
     ],
@@ -24337,8 +25347,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 44.45,
-    "lowestPriceWithShipping": 58.99,
+    "marketPrice": 62.16,
+    "lowestPriceWithShipping": 58.89,
     "color": [
       "Yellow"
     ],
@@ -24363,8 +25373,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 4.89,
-    "lowestPriceWithShipping": 4.83,
+    "marketPrice": 9.17,
+    "lowestPriceWithShipping": 8.72,
     "color": [
       "Red"
     ],
@@ -24390,8 +25400,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 0.86,
-    "lowestPriceWithShipping": 0.64,
+    "marketPrice": 2.35,
+    "lowestPriceWithShipping": 1.37,
     "color": [
       "Red"
     ],
@@ -24409,6 +25419,58 @@
     "productId": 450299
   },
   {
+    "productName": "Monkey.D.Luffy (Starter Deck 11: Uta Deck Battle)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 29.01,
+    "lowestPriceWithShipping": 29.99,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "FILM",
+      "Straw Hat Crew"
+    ],
+    "number": "P-061",
+    "productId": 532115
+  },
+  {
+    "productName": "Monkey.D.Luffy (Starter Deck 11: Uta Deck Battle) [Winner]",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 133.75,
+    "lowestPriceWithShipping": 111.99,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "FILM",
+      "Straw Hat Crew"
+    ],
+    "number": "P-061",
+    "productId": 532116
+  },
+  {
     "productName": "Monkey.D.Luffy (Store Championship Trophy Card)",
     "setName": [
       "One Piece Promotion Cards"
@@ -24416,8 +25478,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 271.28,
-    "lowestPriceWithShipping": 394.99,
+    "marketPrice": 373.74,
+    "lowestPriceWithShipping": 550,
     "color": [
       "Red"
     ],
@@ -24442,8 +25504,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 16.79,
-    "lowestPriceWithShipping": 70,
+    "marketPrice": 28.36,
+    "lowestPriceWithShipping": 15,
     "color": [
       "Red"
     ],
@@ -24468,8 +25530,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1001.2,
-    "lowestPriceWithShipping": 1999.99,
+    "marketPrice": 1134.69,
+    "lowestPriceWithShipping": 2299.95,
     "color": [
       "Red"
     ],
@@ -24494,8 +25556,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 4.07,
-    "lowestPriceWithShipping": 3.75,
+    "marketPrice": 2.22,
+    "lowestPriceWithShipping": 1.92,
     "color": [
       "Red"
     ],
@@ -24520,8 +25582,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 103.44,
-    "lowestPriceWithShipping": 103.99,
+    "marketPrice": 163.01,
+    "lowestPriceWithShipping": 168,
     "color": [
       "Red"
     ],
@@ -24546,8 +25608,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 20.09,
-    "lowestPriceWithShipping": 18.99,
+    "marketPrice": 20.59,
+    "lowestPriceWithShipping": 16.92,
     "color": [
       "Red"
     ],
@@ -24572,8 +25634,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.32,
-    "lowestPriceWithShipping": 0.98,
+    "marketPrice": 1.48,
+    "lowestPriceWithShipping": 2,
     "color": [
       "Black"
     ],
@@ -24597,8 +25659,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.07,
+    "marketPrice": 0.12,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Red"
     ],
@@ -24649,8 +25711,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.4,
-    "lowestPriceWithShipping": 0.17,
+    "marketPrice": 0.41,
+    "lowestPriceWithShipping": 0.15,
     "color": [
       "Blue"
     ],
@@ -24675,8 +25737,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.06,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
     ],
@@ -24700,8 +25762,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.04,
-    "lowestPriceWithShipping": 1.74,
+    "marketPrice": 1.73,
+    "lowestPriceWithShipping": 1.73,
     "color": [
       "Blue"
     ],
@@ -24718,15 +25780,15 @@
     "productId": 530921
   },
   {
-    "productName": "Mr. 1 (Daz.Bonez)",
+    "productName": "Mr.1 (Daz.Bonez)",
     "setName": [
       "Awakening of the New Era"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.07,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
     ],
@@ -24743,55 +25805,6 @@
     "productId": 528635
   },
   {
-    "productName": "Mr. 1 (Daz.Bonez)",
-    "setName": [
-      "Romance Dawn"
-    ],
-    "rarityName": [
-      "Uncommon"
-    ],
-    "marketPrice": 0.12,
-    "lowestPriceWithShipping": 0.05,
-    "color": [
-      "Blue"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Slash"
-    ],
-    "subtypes": [
-      "Baroque Works"
-    ],
-    "number": "OP01-083",
-    "productId": 454614
-  },
-  {
-    "productName": "Mr. 1 (Daz.Bonez)",
-    "setName": [
-      "Awakening of the New Era 1st Anniversary Tournament Cards"
-    ],
-    "rarityName": [
-      "Common"
-    ],
-    "lowestPriceWithShipping": 2.97,
-    "color": [
-      "Purple"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Slash"
-    ],
-    "subtypes": [
-      "Baroque Works"
-    ],
-    "number": "OP05-075",
-    "productId": 530935
-  },
-  {
     "productName": "Mr.1 (Daz.Bonez)",
     "setName": [
       "Paramount War Pre Release Cards"
@@ -24799,7 +25812,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 5.9,
+    "marketPrice": 4.14,
     "lowestPriceWithShipping": 4,
     "color": [
       "Blue"
@@ -24820,13 +25833,38 @@
   {
     "productName": "Mr.1 (Daz.Bonez)",
     "setName": [
+      "Romance Dawn"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "marketPrice": 0.11,
+    "lowestPriceWithShipping": 0.03,
+    "color": [
+      "Blue"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Baroque Works"
+    ],
+    "number": "OP01-083",
+    "productId": 454614
+  },
+  {
+    "productName": "Mr.1 (Daz.Bonez)",
+    "setName": [
       "Paramount War"
     ],
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.41,
-    "lowestPriceWithShipping": 0.23,
+    "marketPrice": 0.37,
+    "lowestPriceWithShipping": 0.14,
     "color": [
       "Blue"
     ],
@@ -24844,6 +25882,31 @@
     "productId": 486401
   },
   {
+    "productName": "Mr.1 (Daz.Bonez)",
+    "setName": [
+      "Awakening of the New Era 1st Anniversary Tournament Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 2.5,
+    "lowestPriceWithShipping": 2.89,
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Baroque Works"
+    ],
+    "number": "OP05-075",
+    "productId": 530935
+  },
+  {
     "productName": "Mr.13 & Ms.Friday",
     "setName": [
       "Kingdoms of Intrigue Pre Release Cards"
@@ -24851,8 +25914,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.95,
-    "lowestPriceWithShipping": 0.99,
+    "marketPrice": 1.32,
+    "lowestPriceWithShipping": 1.14,
     "color": [
       "Purple"
     ],
@@ -24877,8 +25940,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.05,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
     ],
@@ -24898,13 +25961,63 @@
   {
     "productName": "Mr.2.Bon.Kurei (Bentham)",
     "setName": [
+      "Kingdoms of Intrigue Pre Release Cards"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "marketPrice": 1.83,
+    "lowestPriceWithShipping": 1.48,
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "Baroque Works"
+    ],
+    "number": "OP04-069",
+    "productId": 516876
+  },
+  {
+    "productName": "Mr.2.Bon.Kurei (Bentham)",
+    "setName": [
+      "Kingdoms of Intrigue"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "marketPrice": 0.06,
+    "lowestPriceWithShipping": 0.02,
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "Baroque Works"
+    ],
+    "number": "OP04-069",
+    "productId": 516784
+  },
+  {
+    "productName": "Mr.2.Bon.Kurei (Bentham)",
+    "setName": [
       "Romance Dawn"
     ],
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.21,
-    "lowestPriceWithShipping": 0.13,
+    "marketPrice": 0.19,
+    "lowestPriceWithShipping": 0.07,
     "color": [
       "Blue"
     ],
@@ -24928,8 +26041,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.16,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.24,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Blue"
     ],
@@ -24954,8 +26067,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.09,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Black"
     ],
@@ -24972,65 +26085,15 @@
     "productId": 503238
   },
   {
-    "productName": "Mr.2.Bon.Kurei(Bentham)",
-    "setName": [
-      "Kingdoms of Intrigue Pre Release Cards"
-    ],
-    "rarityName": [
-      "Uncommon"
-    ],
-    "marketPrice": 2.08,
-    "lowestPriceWithShipping": 1.51,
-    "color": [
-      "Purple"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Strike"
-    ],
-    "subtypes": [
-      "Baroque Works"
-    ],
-    "number": "OP04-069",
-    "productId": 516876
-  },
-  {
-    "productName": "Mr.2.Bon.Kurei(Bentham)",
-    "setName": [
-      "Kingdoms of Intrigue"
-    ],
-    "rarityName": [
-      "Uncommon"
-    ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.02,
-    "color": [
-      "Purple"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Strike"
-    ],
-    "subtypes": [
-      "Baroque Works"
-    ],
-    "number": "OP04-069",
-    "productId": 516784
-  },
-  {
-    "productName": "Mr.2.Bon.Kurei(Bentham) (Store Championship Participation Pack Vol. 2)",
+    "productName": "Mr.2.Bon.Kurei (Bentham) (Store Championship Participation Pack Vol. 2)",
     "setName": [
       "One Piece Promotion Cards"
     ],
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 5.66,
-    "lowestPriceWithShipping": 6.14,
+    "marketPrice": 15.71,
+    "lowestPriceWithShipping": 13.99,
     "color": [
       "Blue"
     ],
@@ -25055,7 +26118,7 @@
       "Rare"
     ],
     "marketPrice": 0.16,
-    "lowestPriceWithShipping": 0.03,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Blue"
     ],
@@ -25075,12 +26138,37 @@
   {
     "productName": "Mr.3 (Galdino)",
     "setName": [
+      "Kingdoms of Intrigue Pre Release Cards"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "marketPrice": 1.38,
+    "lowestPriceWithShipping": 1.13,
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Special"
+    ],
+    "subtypes": [
+      "Baroque Works"
+    ],
+    "number": "OP04-070",
+    "productId": 516877
+  },
+  {
+    "productName": "Mr.3 (Galdino)",
+    "setName": [
       "Romance Dawn"
     ],
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.1,
     "lowestPriceWithShipping": 0.03,
     "color": [
       "Blue"
@@ -25098,32 +26186,7 @@
     "productId": 454616
   },
   {
-    "productName": "Mr.3(Galdino)",
-    "setName": [
-      "Kingdoms of Intrigue Pre Release Cards"
-    ],
-    "rarityName": [
-      "Uncommon"
-    ],
-    "marketPrice": 1.37,
-    "lowestPriceWithShipping": 1.15,
-    "color": [
-      "Purple"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Special"
-    ],
-    "subtypes": [
-      "Baroque Works"
-    ],
-    "number": "OP04-070",
-    "productId": 516877
-  },
-  {
-    "productName": "Mr.3(Galdino)",
+    "productName": "Mr.3 (Galdino)",
     "setName": [
       "Kingdoms of Intrigue"
     ],
@@ -25148,14 +26211,14 @@
     "productId": 516785
   },
   {
-    "productName": "Mr.4(Babe)",
+    "productName": "Mr.4 (Babe)",
     "setName": [
       "Kingdoms of Intrigue"
     ],
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.09,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -25173,15 +26236,15 @@
     "productId": 516786
   },
   {
-    "productName": "Mr.4(Babe)",
+    "productName": "Mr.4 (Babe)",
     "setName": [
       "Kingdoms of Intrigue Pre Release Cards"
     ],
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 2.52,
-    "lowestPriceWithShipping": 2,
+    "marketPrice": 2.71,
+    "lowestPriceWithShipping": 2.69,
     "color": [
       "Purple"
     ],
@@ -25198,7 +26261,7 @@
     "productId": 516878
   },
   {
-    "productName": "Mr.5(Gem)",
+    "productName": "Mr.5 (Gem)",
     "setName": [
       "Kingdoms of Intrigue"
     ],
@@ -25223,15 +26286,15 @@
     "productId": 514253
   },
   {
-    "productName": "Mr.5(Gem) (Alternate Art)",
+    "productName": "Mr.5 (Gem) (Alternate Art)",
     "setName": [
       "Kingdoms of Intrigue"
     ],
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 3.28,
-    "lowestPriceWithShipping": 3.25,
+    "marketPrice": 5.44,
+    "lowestPriceWithShipping": 4.51,
     "color": [
       "Purple"
     ],
@@ -25255,8 +26318,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.86,
-    "lowestPriceWithShipping": 0.4,
+    "marketPrice": 0.91,
+    "lowestPriceWithShipping": 0.7,
     "color": [
       "Blue"
     ],
@@ -25280,8 +26343,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.62,
-    "lowestPriceWithShipping": 1.19,
+    "marketPrice": 2.37,
+    "lowestPriceWithShipping": 1.52,
     "color": [
       "Purple"
     ],
@@ -25305,8 +26368,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 24.43,
-    "lowestPriceWithShipping": 23.24,
+    "marketPrice": 28.09,
+    "lowestPriceWithShipping": 26.76,
     "color": [
       "Purple"
     ],
@@ -25330,8 +26393,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 2.89,
-    "lowestPriceWithShipping": 3.19,
+    "marketPrice": 6.44,
+    "lowestPriceWithShipping": 5.8,
     "color": [
       "Blue"
     ],
@@ -25350,13 +26413,38 @@
   {
     "productName": "Nami",
     "setName": [
+      "Starter Deck 1 Straw Hat Crew"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 0.31,
+    "lowestPriceWithShipping": 0.11,
+    "color": [
+      "Red"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Special"
+    ],
+    "subtypes": [
+      "Straw Hat Crew"
+    ],
+    "number": "ST01-007",
+    "productId": 288236
+  },
+  {
+    "productName": "Nami",
+    "setName": [
       "Kingdoms of Intrigue Pre Release Cards"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.51,
-    "lowestPriceWithShipping": 7,
+    "marketPrice": 7.75,
+    "lowestPriceWithShipping": 13.25,
     "color": [
       "Red"
     ],
@@ -25376,37 +26464,12 @@
   {
     "productName": "Nami",
     "setName": [
-      "Starter Deck 1 Straw Hat Crew"
-    ],
-    "rarityName": [
-      "Common"
-    ],
-    "marketPrice": 0.28,
-    "lowestPriceWithShipping": 0.1,
-    "color": [
-      "Red"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Special"
-    ],
-    "subtypes": [
-      "Straw Hat Crew"
-    ],
-    "number": "ST01-007",
-    "productId": 288236
-  },
-  {
-    "productName": "Nami",
-    "setName": [
       "Kingdoms of Intrigue"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -25433,7 +26496,7 @@
       "Common"
     ],
     "marketPrice": 6.45,
-    "lowestPriceWithShipping": 4.99,
+    "lowestPriceWithShipping": 5.75,
     "color": [
       "Red"
     ],
@@ -25457,8 +26520,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.85,
-    "lowestPriceWithShipping": 0.4,
+    "marketPrice": 0.61,
+    "lowestPriceWithShipping": 0.25,
     "color": [
       "Red"
     ],
@@ -25482,8 +26545,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 12.68,
-    "lowestPriceWithShipping": 13.95,
+    "marketPrice": 35.14,
+    "lowestPriceWithShipping": 39,
     "color": [
       "Green"
     ],
@@ -25508,8 +26571,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 17.32,
-    "lowestPriceWithShipping": 17.4,
+    "marketPrice": 15.9,
+    "lowestPriceWithShipping": 12.5,
     "color": [
       "Red"
     ],
@@ -25533,8 +26596,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.99,
-    "lowestPriceWithShipping": 0.79,
+    "marketPrice": 1.16,
+    "lowestPriceWithShipping": 0.98,
     "color": [
       "Red"
     ],
@@ -25559,7 +26622,7 @@
       "Rare"
     ],
     "marketPrice": 0.18,
-    "lowestPriceWithShipping": 0.01,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Green"
     ],
@@ -25584,8 +26647,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.23,
-    "lowestPriceWithShipping": 0.12,
+    "marketPrice": 0.24,
+    "lowestPriceWithShipping": 0.17,
     "color": [
       "Blue"
     ],
@@ -25609,8 +26672,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 138.66,
-    "lowestPriceWithShipping": 139.71,
+    "marketPrice": 227.16,
+    "lowestPriceWithShipping": 200.01,
     "color": [
       "Blue"
     ],
@@ -25632,8 +26695,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 41.5,
-    "lowestPriceWithShipping": 39.73,
+    "marketPrice": 66.95,
+    "lowestPriceWithShipping": 67.94,
     "color": [
       "Green"
     ],
@@ -25651,6 +26714,31 @@
     "productId": 482429
   },
   {
+    "productName": "Nami (CS 2023 Celebration Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 227.62,
+    "lowestPriceWithShipping": 192,
+    "color": [
+      "Red"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Special"
+    ],
+    "subtypes": [
+      "Straw Hat Crew"
+    ],
+    "number": "ST01-007",
+    "productId": 525324
+  },
+  {
     "productName": "Nami (Gift Collection 2023)",
     "setName": [
       "One Piece Promotion Cards"
@@ -25658,8 +26746,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 16.36,
-    "lowestPriceWithShipping": 16.17,
+    "marketPrice": 19.5,
+    "lowestPriceWithShipping": 17,
     "color": [
       "Red"
     ],
@@ -25683,8 +26771,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 278.26,
-    "lowestPriceWithShipping": 280,
+    "marketPrice": 386.46,
+    "lowestPriceWithShipping": 330,
     "color": [
       "Red"
     ],
@@ -25708,8 +26796,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 7.49,
-    "lowestPriceWithShipping": 9.93,
+    "marketPrice": 10.48,
+    "lowestPriceWithShipping": 9.45,
     "color": [
       "Red"
     ],
@@ -25733,8 +26821,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 172.14,
-    "lowestPriceWithShipping": 165.51,
+    "marketPrice": 272.82,
+    "lowestPriceWithShipping": 241,
     "color": [
       "Red"
     ],
@@ -25758,8 +26846,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 54.01,
-    "lowestPriceWithShipping": 54.99,
+    "marketPrice": 65.48,
+    "lowestPriceWithShipping": 57,
     "color": [
       "Blue"
     ],
@@ -25783,8 +26871,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.7,
-    "lowestPriceWithShipping": 1.5,
+    "marketPrice": 2.32,
+    "lowestPriceWithShipping": 1.85,
     "color": [
       "Red"
     ],
@@ -25808,8 +26896,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 39.66,
-    "lowestPriceWithShipping": 39.66,
+    "marketPrice": 65.55,
+    "lowestPriceWithShipping": 54,
     "color": [
       "Red"
     ],
@@ -25833,7 +26921,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -25859,8 +26947,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.46,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.44,
+    "lowestPriceWithShipping": 0.24,
     "color": [
       "Red"
     ],
@@ -25885,8 +26973,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.75,
-    "lowestPriceWithShipping": 1.5,
+    "marketPrice": 1.68,
+    "lowestPriceWithShipping": 0.94,
     "color": [
       "Yellow"
     ],
@@ -25911,8 +26999,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.06,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Yellow"
     ],
@@ -25937,8 +27025,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.4,
-    "lowestPriceWithShipping": 2.99,
+    "marketPrice": 2.97,
+    "lowestPriceWithShipping": 2.09,
     "color": [
       "Yellow"
     ],
@@ -25960,8 +27048,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.63,
-    "lowestPriceWithShipping": 0.44,
+    "marketPrice": 0.94,
+    "lowestPriceWithShipping": 0.61,
     "color": [
       "Black"
     ],
@@ -25983,7 +27071,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.62,
+    "marketPrice": 0.61,
     "lowestPriceWithShipping": 0.49,
     "color": [
       "Red"
@@ -26008,7 +27096,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "lowestPriceWithShipping": 3.99,
+    "marketPrice": 3.57,
+    "lowestPriceWithShipping": 0.99,
     "color": [
       "Black"
     ],
@@ -26032,8 +27121,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.06,
+    "marketPrice": 0.07,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
     ],
@@ -26057,7 +27146,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -26082,8 +27171,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.22,
-    "lowestPriceWithShipping": 0.18,
+    "marketPrice": 0.24,
+    "lowestPriceWithShipping": 0.16,
     "color": [
       "Black"
     ],
@@ -26107,7 +27196,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.1,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -26132,8 +27221,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.0972,
-    "lowestPriceWithShipping": 0.03,
+    "marketPrice": 0.11,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Black"
     ],
@@ -26157,7 +27246,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.68,
+    "marketPrice": 0.61,
     "lowestPriceWithShipping": 0.35,
     "color": [
       "Red"
@@ -26182,7 +27271,7 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.09,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue",
@@ -26208,8 +27297,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 41.46,
-    "lowestPriceWithShipping": 45,
+    "marketPrice": 61.13,
+    "lowestPriceWithShipping": 56.09,
     "color": [
       "Blue",
       "Red"
@@ -26234,8 +27323,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 4.8,
-    "lowestPriceWithShipping": 2.25,
+    "marketPrice": 2.63,
+    "lowestPriceWithShipping": 2.23,
     "color": [
       "Red"
     ],
@@ -26259,8 +27348,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 15.7,
-    "lowestPriceWithShipping": 14.95,
+    "marketPrice": 16.25,
+    "lowestPriceWithShipping": 14.5,
     "color": [
       "Red"
     ],
@@ -26284,8 +27373,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.02,
-    "lowestPriceWithShipping": 0.49,
+    "marketPrice": 1.42,
+    "lowestPriceWithShipping": 1.35,
     "color": [
       "Red"
     ],
@@ -26309,8 +27398,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 58.31,
-    "lowestPriceWithShipping": 52.99,
+    "marketPrice": 75.52,
+    "lowestPriceWithShipping": 59.99,
     "color": [
       "Red"
     ],
@@ -26361,7 +27450,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.12,
+    "marketPrice": 0.11,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Green"
@@ -26388,8 +27477,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.35,
-    "lowestPriceWithShipping": 3.49,
+    "marketPrice": 2.44,
+    "lowestPriceWithShipping": 6.99,
     "color": [
       "Green"
     ],
@@ -26415,8 +27504,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 4.05,
-    "lowestPriceWithShipping": 3.98,
+    "marketPrice": 6.6,
+    "lowestPriceWithShipping": 5.01,
     "color": [
       "Green"
     ],
@@ -26442,8 +27531,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.45,
-    "lowestPriceWithShipping": 0.26,
+    "marketPrice": 0.5,
+    "lowestPriceWithShipping": 0.53,
     "color": [
       "Black"
     ],
@@ -26467,7 +27556,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.04,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -26485,6 +27574,54 @@
     "productId": 500035
   },
   {
+    "productName": "New Genesis",
+    "setName": [
+      "Starter Deck 11 Uta"
+    ],
+    "rarityName": [
+      "Super Rare"
+    ],
+    "marketPrice": 3.33,
+    "lowestPriceWithShipping": 2.95,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Event"
+    ],
+    "attribute": null,
+    "subtypes": [
+      "FILM",
+      "Music"
+    ],
+    "number": "ST11-004",
+    "productId": 533882
+  },
+  {
+    "productName": "New Genesis (Starter Deck 11: Uta Deck Battle)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Super Rare"
+    ],
+    "marketPrice": 26.61,
+    "lowestPriceWithShipping": 24.98,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Event"
+    ],
+    "attribute": null,
+    "subtypes": [
+      "FILM",
+      "Music"
+    ],
+    "number": "ST11-004",
+    "productId": 532108
+  },
+  {
     "productName": "New Kama Land",
     "setName": [
       "Paramount War"
@@ -26493,7 +27630,7 @@
       "Common"
     ],
     "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.01,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Blue"
     ],
@@ -26515,7 +27652,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.85,
+    "marketPrice": 2.83,
     "lowestPriceWithShipping": 2.5,
     "color": [
       "Blue"
@@ -26561,7 +27698,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.03,
+    "marketPrice": 1.04,
     "lowestPriceWithShipping": 0.9,
     "color": [
       "Purple"
@@ -26584,8 +27721,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.29,
-    "lowestPriceWithShipping": 3.99,
+    "marketPrice": 4.43,
+    "lowestPriceWithShipping": 3.85,
     "color": [
       "Red"
     ],
@@ -26609,8 +27746,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.16,
-    "lowestPriceWithShipping": 0.09,
+    "marketPrice": 0.14,
+    "lowestPriceWithShipping": 0.08,
     "color": [
       "Green"
     ],
@@ -26635,8 +27772,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 9.15,
-    "lowestPriceWithShipping": 8,
+    "marketPrice": 9.64,
+    "lowestPriceWithShipping": 8.9,
     "color": [
       "Green"
     ],
@@ -26660,7 +27797,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.21,
+    "marketPrice": 0.23,
     "lowestPriceWithShipping": 0.08,
     "color": [
       "Red"
@@ -26680,13 +27817,38 @@
   {
     "productName": "Nico Robin",
     "setName": [
+      "Starter Deck 1 Straw Hat Crew"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 0.15,
+    "lowestPriceWithShipping": 0.02,
+    "color": [
+      "Red"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Wisdom"
+    ],
+    "subtypes": [
+      "Straw Hat Crew"
+    ],
+    "number": "ST01-008",
+    "productId": 288237
+  },
+  {
+    "productName": "Nico Robin",
+    "setName": [
       "Romance Dawn"
     ],
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.7,
-    "lowestPriceWithShipping": 0.38,
+    "marketPrice": 0.52,
+    "lowestPriceWithShipping": 0.17,
     "color": [
       "Red"
     ],
@@ -26710,8 +27872,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 23.6,
-    "lowestPriceWithShipping": 43.99,
+    "marketPrice": 58.83,
+    "lowestPriceWithShipping": 83,
     "color": [
       "Red"
     ],
@@ -26728,31 +27890,6 @@
     "productId": 530892
   },
   {
-    "productName": "Nico Robin",
-    "setName": [
-      "Starter Deck 1 Straw Hat Crew"
-    ],
-    "rarityName": [
-      "Common"
-    ],
-    "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.02,
-    "color": [
-      "Red"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Wisdom"
-    ],
-    "subtypes": [
-      "Straw Hat Crew"
-    ],
-    "number": "ST01-008",
-    "productId": 288237
-  },
-  {
     "productName": "Nico Robin - ST01-008 (Alternate Art)",
     "setName": [
       "One Piece Promotion Cards"
@@ -26760,8 +27897,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 3.2,
-    "lowestPriceWithShipping": 2.99,
+    "marketPrice": 7.35,
+    "lowestPriceWithShipping": 6.3,
     "color": [
       "Red"
     ],
@@ -26785,8 +27922,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 4.36,
-    "lowestPriceWithShipping": 4,
+    "marketPrice": 5.93,
+    "lowestPriceWithShipping": 6.14,
     "color": [
       "Red"
     ],
@@ -26810,8 +27947,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 6.92,
-    "lowestPriceWithShipping": 6.99,
+    "marketPrice": 6.36,
+    "lowestPriceWithShipping": 6.16,
     "color": [
       "Red"
     ],
@@ -26835,8 +27972,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 48.73,
-    "lowestPriceWithShipping": 49.5,
+    "marketPrice": 47.69,
+    "lowestPriceWithShipping": 49,
     "color": [
       "Red"
     ],
@@ -26861,7 +27998,7 @@
       "Uncommon"
     ],
     "marketPrice": 6.87,
-    "lowestPriceWithShipping": 6.24,
+    "lowestPriceWithShipping": 7.56,
     "color": [
       "Blue"
     ],
@@ -26885,8 +28022,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.16,
-    "lowestPriceWithShipping": 0.09,
+    "marketPrice": 0.19,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Blue"
     ],
@@ -26910,8 +28047,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.07,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
     ],
@@ -26936,8 +28073,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.89,
-    "lowestPriceWithShipping": 2.87,
+    "marketPrice": 2.44,
+    "lowestPriceWithShipping": 1.78,
     "color": [
       "Yellow"
     ],
@@ -26987,8 +28124,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 29.21,
-    "lowestPriceWithShipping": 95.989,
+    "marketPrice": 52.31,
+    "lowestPriceWithShipping": 62.99,
     "color": [
       "Purple"
     ],
@@ -27012,8 +28149,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.07,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Purple"
     ],
@@ -27037,8 +28174,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 10.24,
-    "lowestPriceWithShipping": 14.95,
+    "marketPrice": 17.84,
+    "lowestPriceWithShipping": 24,
     "color": [
       "Purple"
     ],
@@ -27062,8 +28199,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.08,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Blue"
     ],
@@ -27085,8 +28222,7 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 40,
-    "lowestPriceWithShipping": 72,
+    "marketPrice": 50,
     "number": null,
     "productId": 514200
   },
@@ -27098,8 +28234,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.27,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.4,
+    "lowestPriceWithShipping": 0.13,
     "color": [
       "Yellow"
     ],
@@ -27150,8 +28286,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.51,
-    "lowestPriceWithShipping": 0.24,
+    "marketPrice": 0.43,
+    "lowestPriceWithShipping": 0.35,
     "color": [
       "Black"
     ],
@@ -27176,8 +28312,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.45,
-    "lowestPriceWithShipping": 0.15,
+    "marketPrice": 0.42,
+    "lowestPriceWithShipping": 0.2,
     "color": [
       "Green"
     ],
@@ -27195,6 +28331,32 @@
     "productId": 454556
   },
   {
+    "productName": "Okiku (CS 2023 Celebration Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Rare"
+    ],
+    "marketPrice": 29.41,
+    "lowestPriceWithShipping": 16,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Land of Wano",
+      "The Akazaya Nine"
+    ],
+    "number": "OP01-035",
+    "productId": 525308
+  },
+  {
     "productName": "Okiku (Judge)",
     "setName": [
       "One Piece Promotion Cards"
@@ -27202,8 +28364,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.38,
-    "lowestPriceWithShipping": 1.16,
+    "marketPrice": 2.12,
+    "lowestPriceWithShipping": 1.8,
     "color": [
       "Green"
     ],
@@ -27228,8 +28390,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.7,
-    "lowestPriceWithShipping": 0.26,
+    "marketPrice": 0.83,
+    "lowestPriceWithShipping": 0.49,
     "color": [
       "Green"
     ],
@@ -27254,8 +28416,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 16.38,
-    "lowestPriceWithShipping": 16.89,
+    "marketPrice": 13.62,
+    "lowestPriceWithShipping": 9.49,
     "color": [
       "Green"
     ],
@@ -27280,7 +28442,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.12,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
@@ -27307,8 +28469,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 11.7,
-    "lowestPriceWithShipping": 8.67,
+    "marketPrice": 10.65,
+    "lowestPriceWithShipping": 16.99,
     "color": [
       "Black"
     ],
@@ -27332,7 +28494,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.13,
+    "marketPrice": 0.15,
     "lowestPriceWithShipping": 0.07,
     "color": [
       "Black"
@@ -27350,6 +28512,31 @@
     "productId": 528641
   },
   {
+    "productName": "One Piece Card Game: English Version 1st Anniversary Set",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "None"
+    ],
+    "marketPrice": 399.98,
+    "number": null,
+    "productId": 536588
+  },
+  {
+    "productName": "One Piece Card Game: Japanese 1st Anniversary Set",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "None"
+    ],
+    "marketPrice": 247.86,
+    "lowestPriceWithShipping": 247.84,
+    "number": null,
+    "productId": 536154
+  },
+  {
     "productName": "One Piece Film Red Uta Promo Pack",
     "setName": [
       "One Piece Promotion Cards"
@@ -27357,8 +28544,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 24.98,
-    "lowestPriceWithShipping": 28.01,
+    "marketPrice": 29.08,
+    "lowestPriceWithShipping": 29.01,
     "number": null,
     "productId": 488903
   },
@@ -27370,7 +28557,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.1,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Green"
@@ -27394,8 +28581,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 3.33,
-    "lowestPriceWithShipping": 3.4,
+    "marketPrice": 3.39,
+    "lowestPriceWithShipping": 3.49,
     "color": [
       "Green"
     ],
@@ -27418,8 +28605,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.18,
-    "lowestPriceWithShipping": 0.06,
+    "marketPrice": 0.24,
+    "lowestPriceWithShipping": 0.15,
     "color": [
       "Purple"
     ],
@@ -27441,8 +28628,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.03,
-    "lowestPriceWithShipping": 0.75,
+    "marketPrice": 1.4,
+    "lowestPriceWithShipping": 0.91,
     "color": [
       "Purple"
     ],
@@ -27457,14 +28644,14 @@
     "productId": 427223
   },
   {
-    "productName": "Oniguma",
+    "productName": "Onigumo",
     "setName": [
       "Paramount War"
     ],
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.03,
     "color": [
       "Black"
@@ -27482,14 +28669,14 @@
     "productId": 486467
   },
   {
-    "productName": "Oniguma",
+    "productName": "Onigumo",
     "setName": [
       "Paramount War Pre Release Cards"
     ],
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.49,
+    "marketPrice": 0.59,
     "lowestPriceWithShipping": 0.25,
     "color": [
       "Black"
@@ -27514,7 +28701,8 @@
     "rarityName": [
       "None"
     ],
-    "lowestPriceWithShipping": 60,
+    "marketPrice": 50,
+    "lowestPriceWithShipping": 50,
     "number": null,
     "productId": 514054
   },
@@ -27526,7 +28714,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.08,
+    "marketPrice": 1.39,
     "lowestPriceWithShipping": 1.44,
     "color": [
       "Black"
@@ -27552,8 +28740,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.08,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
     ],
@@ -27579,7 +28767,7 @@
       "Common"
     ],
     "marketPrice": 0.53,
-    "lowestPriceWithShipping": 0.46,
+    "lowestPriceWithShipping": 0.47,
     "color": [
       "Yellow"
     ],
@@ -27603,7 +28791,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
@@ -27628,8 +28816,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 7.08,
-    "lowestPriceWithShipping": 5.99,
+    "marketPrice": 5.84,
+    "lowestPriceWithShipping": 6.2,
     "color": [
       "Red"
     ],
@@ -27646,6 +28834,29 @@
     "productId": 454518
   },
   {
+    "productName": "Otama (Japanese 1st Anniversary Set)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "color": [
+      "Red"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Special"
+    ],
+    "subtypes": [
+      "Land of Wano"
+    ],
+    "number": "OP01-006",
+    "productId": 536170
+  },
+  {
     "productName": "Otama (Judge)",
     "setName": [
       "One Piece Promotion Cards"
@@ -27653,8 +28864,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 10.29,
-    "lowestPriceWithShipping": 11.45,
+    "marketPrice": 11.64,
+    "lowestPriceWithShipping": 9.73,
     "color": [
       "Red"
     ],
@@ -27678,8 +28889,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 242.97,
-    "lowestPriceWithShipping": 198.99,
+    "marketPrice": 207.34,
+    "lowestPriceWithShipping": 170,
     "color": [
       "Red"
     ],
@@ -27703,8 +28914,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 99.67,
-    "lowestPriceWithShipping": 101,
+    "marketPrice": 100.19,
+    "lowestPriceWithShipping": 99.9,
     "color": [
       "Red"
     ],
@@ -27752,7 +28963,7 @@
       "Promo"
     ],
     "marketPrice": 226.71,
-    "lowestPriceWithShipping": 189.94,
+    "lowestPriceWithShipping": 189.49,
     "color": [
       "Red"
     ],
@@ -27776,8 +28987,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 100.02,
-    "lowestPriceWithShipping": 103.99,
+    "marketPrice": 101.85,
+    "lowestPriceWithShipping": 108,
     "color": [
       "Red"
     ],
@@ -27801,7 +29012,6 @@
     "rarityName": [
       "Promo"
     ],
-    "lowestPriceWithShipping": 1000,
     "color": [
       "Red"
     ],
@@ -27825,7 +29035,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Green"
@@ -27850,8 +29060,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.56,
-    "lowestPriceWithShipping": 0.45,
+    "marketPrice": 0.57,
+    "lowestPriceWithShipping": 0.56,
     "color": [
       "Green"
     ],
@@ -27871,7 +29081,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -27892,8 +29102,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.75,
-    "lowestPriceWithShipping": 0.38,
+    "marketPrice": 0.89,
+    "lowestPriceWithShipping": 0.7,
     "color": [
       "Blue"
     ],
@@ -27916,8 +29126,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.78,
-    "lowestPriceWithShipping": 0.9,
+    "marketPrice": 1.55,
+    "lowestPriceWithShipping": 0.96,
     "color": [
       "Blue"
     ],
@@ -27942,8 +29152,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.41,
-    "lowestPriceWithShipping": 0.13,
+    "marketPrice": 0.25,
+    "lowestPriceWithShipping": 0.06,
     "color": [
       "Blue"
     ],
@@ -27968,8 +29178,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.3,
-    "lowestPriceWithShipping": 0.24,
+    "marketPrice": 0.35,
+    "lowestPriceWithShipping": 0.21,
     "color": [
       "Blue"
     ],
@@ -27994,8 +29204,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 5,
-    "lowestPriceWithShipping": 6,
+    "marketPrice": 4.14,
+    "lowestPriceWithShipping": 2.98,
     "color": [
       "Yellow"
     ],
@@ -28019,7 +29229,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
@@ -28044,7 +29254,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.27,
+    "marketPrice": 0.26,
     "lowestPriceWithShipping": 0.09,
     "color": [
       "Purple"
@@ -28069,7 +29279,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.97,
+    "marketPrice": 1.02,
     "lowestPriceWithShipping": 0.97,
     "color": [
       "Blue"
@@ -28094,8 +29304,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.53,
-    "lowestPriceWithShipping": 2,
+    "marketPrice": 2.99,
+    "lowestPriceWithShipping": 2.5,
     "color": [
       "Purple"
     ],
@@ -28119,8 +29329,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.91,
-    "lowestPriceWithShipping": 1.49,
+    "marketPrice": 2.5,
+    "lowestPriceWithShipping": 2.2,
     "color": [
       "Purple"
     ],
@@ -28144,7 +29354,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
@@ -28169,8 +29379,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.34,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.28,
+    "lowestPriceWithShipping": 0.12,
     "color": [
       "Green"
     ],
@@ -28193,8 +29403,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.65,
-    "lowestPriceWithShipping": 0.47,
+    "marketPrice": 0.58,
+    "lowestPriceWithShipping": 0.2,
     "color": [
       "Green"
     ],
@@ -28217,8 +29427,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 272.43,
-    "lowestPriceWithShipping": 299.95,
+    "marketPrice": 319.43,
+    "lowestPriceWithShipping": 299.98,
     "number": null,
     "productId": 455866
   },
@@ -28230,8 +29440,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 1740.57,
-    "lowestPriceWithShipping": 3028.99,
+    "marketPrice": 2027.99,
+    "lowestPriceWithShipping": 3600,
     "number": null,
     "productId": 455867
   },
@@ -28243,8 +29453,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 10.22,
-    "lowestPriceWithShipping": 10.38,
+    "marketPrice": 14.12,
+    "lowestPriceWithShipping": 13.95,
     "number": null,
     "productId": 455865
   },
@@ -28256,8 +29466,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 9.03,
-    "lowestPriceWithShipping": 9.02,
+    "marketPrice": 9.87,
+    "lowestPriceWithShipping": 10.98,
     "number": null,
     "productId": 482217
   },
@@ -28269,6 +29479,8 @@
     "rarityName": [
       "None"
     ],
+    "marketPrice": 17.64,
+    "lowestPriceWithShipping": 18.74,
     "number": null,
     "productId": 531775
   },
@@ -28280,8 +29492,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.02,
-    "lowestPriceWithShipping": 1.33,
+    "marketPrice": 1.13,
+    "lowestPriceWithShipping": 1.97,
     "color": [
       "Blue"
     ],
@@ -28305,7 +29517,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.11,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
@@ -28330,8 +29542,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 4.25,
-    "lowestPriceWithShipping": 3.9,
+    "marketPrice": 2.09,
+    "lowestPriceWithShipping": 1.5,
     "color": [
       "Purple"
     ],
@@ -28356,8 +29568,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 27.57,
-    "lowestPriceWithShipping": 26,
+    "marketPrice": 19.88,
+    "lowestPriceWithShipping": 18.99,
     "color": [
       "Purple"
     ],
@@ -28382,8 +29594,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.91,
-    "lowestPriceWithShipping": 0.74,
+    "marketPrice": 0.88,
+    "lowestPriceWithShipping": 0.8,
     "color": [
       "Green"
     ],
@@ -28408,7 +29620,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.1,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -28434,8 +29646,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 4.38,
-    "lowestPriceWithShipping": 3.73,
+    "marketPrice": 6.02,
+    "lowestPriceWithShipping": 4.23,
     "color": [
       "Green"
     ],
@@ -28460,7 +29672,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -28486,8 +29698,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.25,
-    "lowestPriceWithShipping": 1.24,
+    "marketPrice": 1.31,
+    "lowestPriceWithShipping": 1.69,
     "color": [
       "Purple"
     ],
@@ -28512,8 +29724,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.09,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Yellow"
     ],
@@ -28538,8 +29750,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 0.27,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.4,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Red"
     ],
@@ -28563,8 +29775,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.03,
+    "marketPrice": 0.05,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
     ],
@@ -28588,8 +29800,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 4.48,
-    "lowestPriceWithShipping": 3.45,
+    "marketPrice": 3.42,
+    "lowestPriceWithShipping": 2.46,
     "color": [
       "Red"
     ],
@@ -28613,8 +29825,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 3.8,
-    "lowestPriceWithShipping": 3.5,
+    "marketPrice": 7.26,
+    "lowestPriceWithShipping": 5.7,
     "color": [
       "Red"
     ],
@@ -28638,8 +29850,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.08,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.06,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Green"
     ],
@@ -28663,8 +29875,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.56,
-    "lowestPriceWithShipping": 0.43,
+    "marketPrice": 0.54,
+    "lowestPriceWithShipping": 0.2,
     "color": [
       "Blue"
     ],
@@ -28688,8 +29900,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 18.48,
-    "lowestPriceWithShipping": 16.95,
+    "marketPrice": 24.37,
+    "lowestPriceWithShipping": 18,
     "color": [
       "Blue"
     ],
@@ -28713,8 +29925,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 3.47,
-    "lowestPriceWithShipping": 3.5,
+    "marketPrice": 9.14,
+    "lowestPriceWithShipping": 4.49,
     "color": [
       "Blue"
     ],
@@ -28738,8 +29950,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 0.34,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.36,
+    "lowestPriceWithShipping": 0.13,
     "color": [
       "Green"
     ],
@@ -28763,8 +29975,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 5.8,
-    "lowestPriceWithShipping": 6.29,
+    "marketPrice": 6.73,
+    "lowestPriceWithShipping": 6.97,
     "color": [
       "Green"
     ],
@@ -28788,8 +30000,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 186.61,
-    "lowestPriceWithShipping": 189.96,
+    "marketPrice": 209.14,
+    "lowestPriceWithShipping": 215,
     "number": null,
     "productId": 477176
   },
@@ -28801,8 +30013,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 1606.92,
-    "lowestPriceWithShipping": 2049.99,
+    "marketPrice": 2134.92,
+    "lowestPriceWithShipping": 2999.99,
     "number": null,
     "productId": 477177
   },
@@ -28814,8 +30026,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 6.17,
-    "lowestPriceWithShipping": 6.9,
+    "marketPrice": 7.88,
+    "lowestPriceWithShipping": 8.45,
     "number": null,
     "productId": 477175
   },
@@ -28827,8 +30039,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 9.5436,
-    "lowestPriceWithShipping": 9.56,
+    "marketPrice": 9.68,
+    "lowestPriceWithShipping": 9.69,
     "number": null,
     "productId": 502624
   },
@@ -28840,6 +30052,8 @@
     "rarityName": [
       "None"
     ],
+    "marketPrice": 13.03,
+    "lowestPriceWithShipping": 12.95,
     "number": null,
     "productId": 531776
   },
@@ -28851,8 +30065,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.68,
-    "lowestPriceWithShipping": 0.4,
+    "marketPrice": 0.85,
+    "lowestPriceWithShipping": 0.75,
     "color": [
       "Blue"
     ],
@@ -28874,8 +30088,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.06,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
     ],
@@ -28897,8 +30111,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.14,
-    "lowestPriceWithShipping": 0.09,
+    "marketPrice": 0.19,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Red"
     ],
@@ -28922,8 +30136,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 0.79,
-    "lowestPriceWithShipping": 0.48,
+    "marketPrice": 0.98,
+    "lowestPriceWithShipping": 0.6,
     "color": [
       "Yellow"
     ],
@@ -28948,8 +30162,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 9.48,
-    "lowestPriceWithShipping": 8.95,
+    "marketPrice": 9.11,
+    "lowestPriceWithShipping": 9.38,
     "color": [
       "Red"
     ],
@@ -28973,8 +30187,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 80.34,
-    "lowestPriceWithShipping": 79.89,
+    "marketPrice": 110.2,
+    "lowestPriceWithShipping": 90.9,
     "color": [
       "Red"
     ],
@@ -28991,6 +30205,31 @@
     "productId": 497934
   },
   {
+    "productName": "Portgas.D.Ace (CS 2023 Event Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 73.51,
+    "lowestPriceWithShipping": 45.9,
+    "color": [
+      "Red"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Special"
+    ],
+    "subtypes": [
+      "Whitebeard Pirates"
+    ],
+    "number": "P-028",
+    "productId": 525299
+  },
+  {
     "productName": "Portgas.D.Ace (Event Pack Vol. 1)",
     "setName": [
       "One Piece Promotion Cards"
@@ -28998,8 +30237,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 10.87,
-    "lowestPriceWithShipping": 10.88,
+    "marketPrice": 27.57,
+    "lowestPriceWithShipping": 22.69,
     "color": [
       "Red"
     ],
@@ -29023,8 +30262,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 6.61,
-    "lowestPriceWithShipping": 5.72,
+    "marketPrice": 8.34,
+    "lowestPriceWithShipping": 8.34,
     "color": [
       "Red"
     ],
@@ -29048,8 +30287,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 59.29,
-    "lowestPriceWithShipping": 54.99,
+    "marketPrice": 80.4,
+    "lowestPriceWithShipping": 65.93,
     "color": [
       "Red"
     ],
@@ -29073,8 +30312,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 968.32,
-    "lowestPriceWithShipping": 995.01,
+    "marketPrice": 1144.34,
+    "lowestPriceWithShipping": 1494.95,
     "color": [
       "Red"
     ],
@@ -29098,8 +30337,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 37.49,
-    "lowestPriceWithShipping": 38.81,
+    "marketPrice": 55.91,
+    "lowestPriceWithShipping": 41.49,
     "color": [
       "Red"
     ],
@@ -29123,8 +30362,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.38,
-    "lowestPriceWithShipping": 0.99,
+    "marketPrice": 1.29,
+    "lowestPriceWithShipping": 0.98,
     "color": [
       "Yellow"
     ],
@@ -29173,7 +30412,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.12,
+    "marketPrice": 0.16,
     "lowestPriceWithShipping": 0.07,
     "color": [
       "Yellow"
@@ -29189,6 +30428,19 @@
     "productId": 500153
   },
   {
+    "productName": "Premium Card Collection -BANDAI CARD GAMES Fest. 23-24 Edition-",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "None"
+    ],
+    "marketPrice": 148.87,
+    "lowestPriceWithShipping": 148.83,
+    "number": null,
+    "productId": 536278
+  },
+  {
     "productName": "Premium Card Collection -Best Selection Vol. 1-",
     "setName": [
       "One Piece Promotion Cards"
@@ -29196,8 +30448,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 146.43,
-    "lowestPriceWithShipping": 145,
+    "marketPrice": 145.7,
+    "lowestPriceWithShipping": 144,
     "number": null,
     "productId": 525294
   },
@@ -29209,8 +30461,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 155.82,
-    "lowestPriceWithShipping": 149.99,
+    "marketPrice": 152.08,
+    "lowestPriceWithShipping": 144.99,
     "number": null,
     "productId": 527128
   },
@@ -29222,8 +30474,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 46.41,
-    "lowestPriceWithShipping": 38.99,
+    "marketPrice": 48.39,
+    "lowestPriceWithShipping": 47.94,
     "number": null,
     "productId": 504466
   },
@@ -29235,8 +30487,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 81.38,
-    "lowestPriceWithShipping": 69.92,
+    "marketPrice": 89.28,
+    "lowestPriceWithShipping": 91.99,
     "number": null,
     "productId": 485271
   },
@@ -29249,7 +30501,7 @@
       "Common"
     ],
     "marketPrice": 0.12,
-    "lowestPriceWithShipping": 0.01,
+    "lowestPriceWithShipping": 0.07,
     "color": [
       "Yellow"
     ],
@@ -29274,8 +30526,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 19.4,
-    "lowestPriceWithShipping": 21.95,
+    "marketPrice": 20.88,
+    "lowestPriceWithShipping": 21,
     "number": null,
     "productId": 457043
   },
@@ -29287,8 +30539,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 8.07,
-    "lowestPriceWithShipping": 8.7,
+    "marketPrice": 9.38,
+    "lowestPriceWithShipping": 10.36,
     "number": null,
     "productId": 483109
   },
@@ -29300,8 +30552,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 2.62,
-    "lowestPriceWithShipping": 2.14,
+    "marketPrice": 3.58,
+    "lowestPriceWithShipping": 3.19,
     "color": [
       "Green"
     ],
@@ -29324,8 +30576,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.12,
-    "lowestPriceWithShipping": 0.09,
+    "marketPrice": 0.1,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Purple"
     ],
@@ -29347,8 +30599,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 14.99,
-    "lowestPriceWithShipping": 13.94,
+    "marketPrice": 11.6,
+    "lowestPriceWithShipping": 10.25,
     "color": [
       "Purple"
     ],
@@ -29370,8 +30622,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.07,
+    "marketPrice": 0.15,
+    "lowestPriceWithShipping": 0.09,
     "color": [
       "Purple"
     ],
@@ -29393,8 +30645,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 39.05,
-    "lowestPriceWithShipping": 38.5,
+    "marketPrice": 31.26,
+    "lowestPriceWithShipping": 31.98,
     "color": [
       "Purple"
     ],
@@ -29418,8 +30670,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.26,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.25,
+    "lowestPriceWithShipping": 0.08,
     "color": [
       "Purple"
     ],
@@ -29443,8 +30695,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 2.02,
-    "lowestPriceWithShipping": 3.5,
+    "marketPrice": 2.5,
+    "lowestPriceWithShipping": 2.98,
     "color": [
       "Blue"
     ],
@@ -29468,8 +30720,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 39.53,
-    "lowestPriceWithShipping": 35,
+    "marketPrice": 34.18,
+    "lowestPriceWithShipping": 34,
     "color": [
       "Purple"
     ],
@@ -29493,7 +30745,7 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.1,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue",
@@ -29519,8 +30771,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 22.85,
-    "lowestPriceWithShipping": 24,
+    "marketPrice": 28.61,
+    "lowestPriceWithShipping": 27.68,
     "color": [
       "Blue",
       "Yellow"
@@ -29545,7 +30797,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
@@ -29570,8 +30822,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 44.8,
-    "lowestPriceWithShipping": 48.96,
+    "marketPrice": 33.38,
+    "lowestPriceWithShipping": 27.99,
     "color": [
       "Purple"
     ],
@@ -29595,8 +30847,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.16,
-    "lowestPriceWithShipping": 0.11,
+    "marketPrice": 0.56,
+    "lowestPriceWithShipping": 0.25,
     "color": [
       "Yellow"
     ],
@@ -29619,8 +30871,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 9.16,
-    "lowestPriceWithShipping": 9.49,
+    "marketPrice": 25.38,
+    "lowestPriceWithShipping": 14,
     "color": [
       "Purple"
     ],
@@ -29645,7 +30897,6 @@
       "Common"
     ],
     "marketPrice": 1200,
-    "lowestPriceWithShipping": 1500,
     "color": [
       "Purple"
     ],
@@ -29669,7 +30920,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.54,
+    "marketPrice": 0.53,
     "lowestPriceWithShipping": 0.4,
     "color": [
       "Yellow"
@@ -29721,8 +30972,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 4.78,
-    "lowestPriceWithShipping": 4.44,
+    "marketPrice": 4.76,
+    "lowestPriceWithShipping": 4,
     "color": [
       "Red"
     ],
@@ -29744,8 +30995,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.26,
-    "lowestPriceWithShipping": 0.19,
+    "marketPrice": 0.24,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Green"
     ],
@@ -29763,6 +31014,32 @@
     "productId": 454577
   },
   {
+    "productName": "Raizo (CS 2023 Event Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "marketPrice": 30.46,
+    "lowestPriceWithShipping": 20.7,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Land of Wano",
+      "The Akazaya Nine"
+    ],
+    "number": "OP01-052",
+    "productId": 525295
+  },
+  {
     "productName": "Raizo (Event Pack Vol. 2)",
     "setName": [
       "One Piece Promotion Cards"
@@ -29770,8 +31047,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 4.9,
-    "lowestPriceWithShipping": 4.77,
+    "marketPrice": 4.36,
+    "lowestPriceWithShipping": 1.98,
     "color": [
       "Green"
     ],
@@ -29796,8 +31073,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.64,
-    "lowestPriceWithShipping": 0.5,
+    "marketPrice": 0.68,
+    "lowestPriceWithShipping": 0.49,
     "color": [
       "Red"
     ],
@@ -29822,7 +31099,7 @@
       "Uncommon"
     ],
     "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.05,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Red"
     ],
@@ -29847,7 +31124,7 @@
       "Common"
     ],
     "marketPrice": 0.06,
-    "lowestPriceWithShipping": 0.02,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
     ],
@@ -29872,8 +31149,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 4.46,
-    "lowestPriceWithShipping": 3.98,
+    "marketPrice": 4.31,
+    "lowestPriceWithShipping": 2.83,
     "color": [
       "Yellow"
     ],
@@ -29898,8 +31175,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 4.93,
-    "lowestPriceWithShipping": 4,
+    "marketPrice": 6.61,
+    "lowestPriceWithShipping": 5.64,
     "color": [
       "Black"
     ],
@@ -29923,7 +31200,7 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.13,
+    "marketPrice": 0.09,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue",
@@ -29949,8 +31226,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 59.67,
-    "lowestPriceWithShipping": 59,
+    "marketPrice": 75.23,
+    "lowestPriceWithShipping": 69.99,
     "color": [
       "Blue",
       "Black"
@@ -29975,8 +31252,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.34,
-    "lowestPriceWithShipping": 0.18,
+    "marketPrice": 0.24,
+    "lowestPriceWithShipping": 0.15,
     "color": [
       "Black"
     ],
@@ -30000,8 +31277,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 58.89,
-    "lowestPriceWithShipping": 55.98,
+    "marketPrice": 57.55,
+    "lowestPriceWithShipping": 56.89,
     "color": [
       "Black"
     ],
@@ -30025,8 +31302,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.29,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.34,
+    "lowestPriceWithShipping": 0.2,
     "color": [
       "Green"
     ],
@@ -30049,8 +31326,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.15,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.21,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Green"
     ],
@@ -30073,8 +31350,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 4.38,
-    "lowestPriceWithShipping": 5,
+    "marketPrice": 4.84,
+    "lowestPriceWithShipping": 4.9,
     "number": null,
     "productId": 487126
   },
@@ -30086,8 +31363,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 16,
-    "lowestPriceWithShipping": 10.979,
+    "marketPrice": 13.38,
+    "lowestPriceWithShipping": 40,
     "color": [
       "Red"
     ],
@@ -30109,8 +31386,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.1,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
     ],
@@ -30132,8 +31409,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.89,
-    "lowestPriceWithShipping": 2.79,
+    "marketPrice": 2.15,
+    "lowestPriceWithShipping": 1.98,
     "color": [
       "Black"
     ],
@@ -30157,7 +31434,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.11,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -30182,7 +31459,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.1,
+    "marketPrice": 0.11,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Purple"
@@ -30208,8 +31485,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.15,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.13,
+    "lowestPriceWithShipping": 0.09,
     "color": [
       "Black"
     ],
@@ -30233,8 +31510,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 43.72,
-    "lowestPriceWithShipping": 42,
+    "marketPrice": 87.11,
+    "lowestPriceWithShipping": 67.5,
     "color": [
       "Black"
     ],
@@ -30256,8 +31533,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 0.53,
-    "lowestPriceWithShipping": 0.23,
+    "marketPrice": 0.59,
+    "lowestPriceWithShipping": 0.4,
     "color": [
       "Black"
     ],
@@ -30281,8 +31558,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 10.58,
-    "lowestPriceWithShipping": 9,
+    "marketPrice": 16.89,
+    "lowestPriceWithShipping": 14.9,
     "color": [
       "Black"
     ],
@@ -30306,8 +31583,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 37.05,
-    "lowestPriceWithShipping": 40.14,
+    "marketPrice": 62.67,
+    "lowestPriceWithShipping": 58.39,
     "color": [
       "Black"
     ],
@@ -30331,8 +31608,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 2.29,
-    "lowestPriceWithShipping": 1.99,
+    "marketPrice": 2.72,
+    "lowestPriceWithShipping": 2.25,
     "color": [
       "Black"
     ],
@@ -30356,8 +31633,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 41.09,
-    "lowestPriceWithShipping": 39.99,
+    "marketPrice": 45.72,
+    "lowestPriceWithShipping": 38,
     "color": [
       "Black"
     ],
@@ -30381,8 +31658,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.53,
-    "lowestPriceWithShipping": 0.4,
+    "marketPrice": 0.55,
+    "lowestPriceWithShipping": 0.35,
     "color": [
       "Blue"
     ],
@@ -30407,7 +31684,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.04,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
@@ -30433,8 +31710,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 488.93,
-    "lowestPriceWithShipping": 489,
+    "marketPrice": 570.48,
+    "lowestPriceWithShipping": 535,
     "number": null,
     "productId": 450086
   },
@@ -30446,8 +31723,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 2209.92,
-    "lowestPriceWithShipping": 7499.69,
+    "marketPrice": 2639.04,
+    "lowestPriceWithShipping": 6400,
     "number": null,
     "productId": 450087
   },
@@ -30459,8 +31736,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 18.51,
-    "lowestPriceWithShipping": 20,
+    "marketPrice": 22.99,
+    "lowestPriceWithShipping": 19.95,
     "number": null,
     "productId": 450085
   },
@@ -30472,7 +31749,8 @@
     "rarityName": [
       "None"
     ],
-    "lowestPriceWithShipping": 1000,
+    "marketPrice": 29.97,
+    "lowestPriceWithShipping": 32,
     "number": null,
     "productId": 531774
   },
@@ -30484,8 +31762,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.14,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.13,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Red"
     ],
@@ -30510,8 +31788,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 14.23,
-    "lowestPriceWithShipping": 14.64,
+    "marketPrice": 15.01,
+    "lowestPriceWithShipping": 15.01,
     "color": [
       "Green"
     ],
@@ -30536,8 +31814,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.17,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.13,
+    "lowestPriceWithShipping": 0.08,
     "color": [
       "Green"
     ],
@@ -30563,8 +31841,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 6.62,
-    "lowestPriceWithShipping": 6,
+    "marketPrice": 9.12,
+    "lowestPriceWithShipping": 12,
     "color": [
       "Red"
     ],
@@ -30589,7 +31867,7 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 0.68,
+    "marketPrice": 0.72,
     "lowestPriceWithShipping": 0.49,
     "color": [
       "Red"
@@ -30615,8 +31893,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 24.66,
-    "lowestPriceWithShipping": 22.99,
+    "marketPrice": 38.96,
+    "lowestPriceWithShipping": 36.95,
     "color": [
       "Red"
     ],
@@ -30641,7 +31919,7 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 2947,
+    "marketPrice": 3964.67,
     "color": [
       "Red"
     ],
@@ -30666,8 +31944,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.21,
-    "lowestPriceWithShipping": 0.68,
+    "marketPrice": 1.9,
+    "lowestPriceWithShipping": 1.99,
     "color": [
       "Red"
     ],
@@ -30692,7 +31970,7 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1482.49,
+    "marketPrice": 1473.75,
     "color": [
       "Red"
     ],
@@ -30717,8 +31995,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.51,
-    "lowestPriceWithShipping": 0.25,
+    "marketPrice": 0.7,
+    "lowestPriceWithShipping": 0.35,
     "color": [
       "Red"
     ],
@@ -30743,8 +32021,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 280.93,
-    "lowestPriceWithShipping": 273.99,
+    "marketPrice": 331.78,
+    "lowestPriceWithShipping": 309.99,
     "color": [
       "Red"
     ],
@@ -30769,8 +32047,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 2.84,
-    "lowestPriceWithShipping": 2.5,
+    "marketPrice": 3.61,
+    "lowestPriceWithShipping": 3,
     "color": [
       "Red"
     ],
@@ -30795,8 +32073,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 90.33,
-    "lowestPriceWithShipping": 90.33,
+    "marketPrice": 133.98,
+    "lowestPriceWithShipping": 125,
     "color": [
       "Red"
     ],
@@ -30821,8 +32099,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1299.99,
-    "lowestPriceWithShipping": 989.99,
+    "marketPrice": 1196.89,
+    "lowestPriceWithShipping": 2000,
     "color": [
       "Red"
     ],
@@ -30847,6 +32125,7 @@
     "rarityName": [
       "Super Rare"
     ],
+    "lowestPriceWithShipping": 5000,
     "color": null,
     "cardType": [
       "Character"
@@ -30866,8 +32145,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 6.11,
-    "lowestPriceWithShipping": 5.69,
+    "marketPrice": 6.57,
+    "lowestPriceWithShipping": 5.74,
     "color": [
       "Red"
     ],
@@ -30892,8 +32171,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 2.71,
-    "lowestPriceWithShipping": 2.58,
+    "marketPrice": 3.27,
+    "lowestPriceWithShipping": 2.99,
     "color": [
       "Red"
     ],
@@ -30918,8 +32197,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 17.53,
-    "lowestPriceWithShipping": 16.49,
+    "marketPrice": 24.45,
+    "lowestPriceWithShipping": 23.55,
     "color": [
       "Blue"
     ],
@@ -30943,7 +32222,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.27,
+    "marketPrice": 0.18,
     "lowestPriceWithShipping": 0.07,
     "color": [
       "Red"
@@ -30967,8 +32246,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.61,
-    "lowestPriceWithShipping": 0.33,
+    "marketPrice": 1.15,
+    "lowestPriceWithShipping": 4.48,
     "color": [
       "Blue"
     ],
@@ -30992,7 +32271,7 @@
       "Common"
     ],
     "marketPrice": 0.18,
-    "lowestPriceWithShipping": 0.01,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Blue"
     ],
@@ -31015,8 +32294,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 8.16,
-    "lowestPriceWithShipping": 8.15,
+    "marketPrice": 8.15,
+    "lowestPriceWithShipping": 8.24,
     "color": [
       "Black"
     ],
@@ -31042,7 +32321,7 @@
       "Leader"
     ],
     "marketPrice": 0.12,
-    "lowestPriceWithShipping": 0.08,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Red",
       "Black"
@@ -31067,8 +32346,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 40.81,
-    "lowestPriceWithShipping": 40.47,
+    "marketPrice": 56.14,
+    "lowestPriceWithShipping": 47.86,
     "color": [
       "Red",
       "Black"
@@ -31093,8 +32372,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 0.45,
-    "lowestPriceWithShipping": 0.15,
+    "marketPrice": 0.69,
+    "lowestPriceWithShipping": 0.2,
     "color": [
       "Red"
     ],
@@ -31118,8 +32397,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 7.22,
-    "lowestPriceWithShipping": 6.23,
+    "marketPrice": 11.21,
+    "lowestPriceWithShipping": 9.67,
     "color": [
       "Red"
     ],
@@ -31143,8 +32422,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 59.81,
-    "lowestPriceWithShipping": 81.99,
+    "marketPrice": 52.2,
+    "lowestPriceWithShipping": 48.9,
     "color": [
       "Black"
     ],
@@ -31169,8 +32448,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 528.76,
-    "lowestPriceWithShipping": 580,
+    "marketPrice": 672.21,
+    "lowestPriceWithShipping": 650,
     "color": [
       "Black"
     ],
@@ -31195,8 +32474,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 222.96,
-    "lowestPriceWithShipping": 270,
+    "marketPrice": 310,
+    "lowestPriceWithShipping": 372,
     "color": [
       "Black"
     ],
@@ -31221,7 +32500,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.03,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Red"
@@ -31246,8 +32525,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.36,
-    "lowestPriceWithShipping": 2.23,
+    "marketPrice": 2.67,
+    "lowestPriceWithShipping": 0.94,
     "color": [
       "Black"
     ],
@@ -31271,8 +32550,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.04,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
     ],
@@ -31296,8 +32575,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.93,
-    "lowestPriceWithShipping": 3.84,
+    "marketPrice": 3.1,
+    "lowestPriceWithShipping": 2.56,
     "color": [
       "Black"
     ],
@@ -31321,7 +32600,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -31346,8 +32625,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.99,
-    "lowestPriceWithShipping": 4.01,
+    "marketPrice": 3.88,
+    "lowestPriceWithShipping": 2.95,
     "color": [
       "Black"
     ],
@@ -31371,8 +32650,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.05,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
     ],
@@ -31396,8 +32675,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 2.58,
-    "lowestPriceWithShipping": 2.23,
+    "marketPrice": 2.28,
+    "lowestPriceWithShipping": 1.85,
     "color": [
       "Black"
     ],
@@ -31422,7 +32701,7 @@
       "Leader"
     ],
     "marketPrice": 0.51,
-    "lowestPriceWithShipping": 0.3,
+    "lowestPriceWithShipping": 0.42,
     "color": [
       "Black"
     ],
@@ -31446,8 +32725,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.14,
-    "lowestPriceWithShipping": 0.08,
+    "marketPrice": 0.16,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Blue",
       "Black"
@@ -31472,8 +32751,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 117.07,
-    "lowestPriceWithShipping": 108.99,
+    "marketPrice": 112.3,
+    "lowestPriceWithShipping": 110,
     "color": [
       "Blue",
       "Black"
@@ -31498,8 +32777,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 23.76,
-    "lowestPriceWithShipping": 23.81,
+    "marketPrice": 22.71,
+    "lowestPriceWithShipping": 18.19,
     "color": [
       "Black"
     ],
@@ -31524,7 +32803,7 @@
       "Promo"
     ],
     "marketPrice": 977.19,
-    "lowestPriceWithShipping": 1999.6,
+    "lowestPriceWithShipping": 2999,
     "color": [
       "Black"
     ],
@@ -31548,8 +32827,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 34.12,
-    "lowestPriceWithShipping": 31,
+    "marketPrice": 39.86,
+    "lowestPriceWithShipping": 36.94,
     "color": [
       "Black"
     ],
@@ -31573,8 +32852,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.64,
-    "lowestPriceWithShipping": 0.48,
+    "marketPrice": 0.62,
+    "lowestPriceWithShipping": 0.49,
     "color": [
       "Purple"
     ],
@@ -31623,8 +32902,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.11,
-    "lowestPriceWithShipping": 0.07,
+    "marketPrice": 0.09,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
     ],
@@ -31648,8 +32927,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 8.99,
-    "lowestPriceWithShipping": 8,
+    "marketPrice": 6.4,
+    "lowestPriceWithShipping": 6.01,
     "color": [
       "Purple"
     ],
@@ -31674,7 +32953,7 @@
       "Leader"
     ],
     "marketPrice": 0.18,
-    "lowestPriceWithShipping": 0.12,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Blue",
       "Green"
@@ -31694,38 +32973,13 @@
   {
     "productName": "Sanji",
     "setName": [
-      "Romance Dawn"
-    ],
-    "rarityName": [
-      "Rare"
-    ],
-    "marketPrice": 2.26,
-    "lowestPriceWithShipping": 2,
-    "color": [
-      "Red"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Strike"
-    ],
-    "subtypes": [
-      "Straw Hat Crew"
-    ],
-    "number": "OP01-013",
-    "productId": 454529
-  },
-  {
-    "productName": "Sanji",
-    "setName": [
       "Starter Deck 1 Straw Hat Crew"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.16,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.23,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Red"
     ],
@@ -31744,13 +32998,38 @@
   {
     "productName": "Sanji",
     "setName": [
+      "Romance Dawn"
+    ],
+    "rarityName": [
+      "Rare"
+    ],
+    "marketPrice": 1.74,
+    "lowestPriceWithShipping": 1.89,
+    "color": [
+      "Red"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "Straw Hat Crew"
+    ],
+    "number": "OP01-013",
+    "productId": 454529
+  },
+  {
+    "productName": "Sanji",
+    "setName": [
       "Ultra Deck The Three Captains"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.14,
-    "lowestPriceWithShipping": 0.07,
+    "marketPrice": 0.18,
+    "lowestPriceWithShipping": 0.09,
     "color": [
       "Red"
     ],
@@ -31774,8 +33053,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.72,
-    "lowestPriceWithShipping": 0.45,
+    "marketPrice": 0.79,
+    "lowestPriceWithShipping": 0.35,
     "color": [
       "Yellow"
     ],
@@ -31799,7 +33078,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.95,
+    "marketPrice": 0.89,
     "lowestPriceWithShipping": 0.8,
     "color": [
       "Red"
@@ -31824,8 +33103,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 8.6416,
-    "lowestPriceWithShipping": 8.99,
+    "marketPrice": 10.79,
+    "lowestPriceWithShipping": 8.46,
     "color": [
       "Red"
     ],
@@ -31849,8 +33128,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.18,
-    "lowestPriceWithShipping": 2,
+    "marketPrice": 2.69,
+    "lowestPriceWithShipping": 9.99,
     "color": [
       "Red"
     ],
@@ -31875,7 +33154,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -31901,8 +33180,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 9.75,
-    "lowestPriceWithShipping": 9.26,
+    "marketPrice": 7.76,
+    "lowestPriceWithShipping": 7.74,
     "color": [
       "Yellow"
     ],
@@ -31926,8 +33205,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 53.69,
-    "lowestPriceWithShipping": 55.99,
+    "marketPrice": 54.87,
+    "lowestPriceWithShipping": 53.99,
     "color": [
       "Yellow"
     ],
@@ -31951,8 +33230,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 70.05,
-    "lowestPriceWithShipping": 69.99,
+    "marketPrice": 96.27,
+    "lowestPriceWithShipping": 83.78,
     "color": [
       "Blue",
       "Green"
@@ -31970,6 +33249,31 @@
     "productId": 483628
   },
   {
+    "productName": "Sanji (CS 2023 Event Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 34.28,
+    "lowestPriceWithShipping": 22.9,
+    "color": [
+      "Yellow"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "The Vinsmoke Family"
+    ],
+    "number": "P-034",
+    "productId": 525305
+  },
+  {
     "productName": "Sanji (Demo Deck 2023)",
     "setName": [
       "One Piece Promotion Cards"
@@ -31977,8 +33281,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.28,
-    "lowestPriceWithShipping": 0.2,
+    "marketPrice": 0.44,
+    "lowestPriceWithShipping": 0.22,
     "color": [
       "Red"
     ],
@@ -32002,8 +33306,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 8.73,
-    "lowestPriceWithShipping": 9.48,
+    "marketPrice": 11.91,
+    "lowestPriceWithShipping": 10,
     "color": [
       "Yellow"
     ],
@@ -32027,8 +33331,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 7.3892,
-    "lowestPriceWithShipping": 6.25,
+    "marketPrice": 7.42,
+    "lowestPriceWithShipping": 7,
     "color": [
       "Red"
     ],
@@ -32052,8 +33356,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 33.51,
-    "lowestPriceWithShipping": 28.65,
+    "marketPrice": 31.38,
+    "lowestPriceWithShipping": 79.49,
     "color": [
       "Red"
     ],
@@ -32077,8 +33381,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 14.89,
-    "lowestPriceWithShipping": 17.89,
+    "marketPrice": 27.03,
+    "lowestPriceWithShipping": 49.86,
     "color": [
       "Red"
     ],
@@ -32126,8 +33430,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 30.77,
-    "lowestPriceWithShipping": 44.93,
+    "marketPrice": 32.4,
+    "lowestPriceWithShipping": 69,
     "color": [
       "Red"
     ],
@@ -32151,8 +33455,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 14.77,
-    "lowestPriceWithShipping": 22.97,
+    "marketPrice": 30.04,
+    "lowestPriceWithShipping": 30,
     "color": [
       "Red"
     ],
@@ -32199,8 +33503,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 41.82,
-    "lowestPriceWithShipping": 38.99,
+    "marketPrice": 51.71,
+    "lowestPriceWithShipping": 52.97,
     "color": [
       "Red"
     ],
@@ -32224,8 +33528,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.68,
-    "lowestPriceWithShipping": 2,
+    "marketPrice": 10.05,
+    "lowestPriceWithShipping": 9.98,
     "color": [
       "Red"
     ],
@@ -32249,8 +33553,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 13.39,
-    "lowestPriceWithShipping": 18,
+    "marketPrice": 20.18,
+    "lowestPriceWithShipping": 17,
     "color": [
       "Blue"
     ],
@@ -32274,8 +33578,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 9.94,
-    "lowestPriceWithShipping": 10.99,
+    "marketPrice": 19.67,
+    "lowestPriceWithShipping": 12.99,
     "color": [
       "Yellow"
     ],
@@ -32299,8 +33603,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 42.59,
-    "lowestPriceWithShipping": 36.99,
+    "marketPrice": 41.19,
+    "lowestPriceWithShipping": 40,
     "color": [
       "Blue"
     ],
@@ -32322,8 +33626,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.98,
-    "lowestPriceWithShipping": 0.5,
+    "marketPrice": 1.24,
+    "lowestPriceWithShipping": 1.05,
     "color": [
       "Blue"
     ],
@@ -32345,8 +33649,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.04,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
     ],
@@ -32370,8 +33674,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.5,
-    "lowestPriceWithShipping": 0.99,
+    "marketPrice": 1.15,
+    "lowestPriceWithShipping": 1.12,
     "color": [
       "Green"
     ],
@@ -32390,38 +33694,13 @@
   {
     "productName": "Sasaki",
     "setName": [
-      "Kingdoms of Intrigue"
-    ],
-    "rarityName": [
-      "Uncommon"
-    ],
-    "marketPrice": 0.15,
-    "lowestPriceWithShipping": 0.05,
-    "color": [
-      "Blue"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Strike"
-    ],
-    "subtypes": [
-      "Animal Kingdom Pirates"
-    ],
-    "number": "OP04-048",
-    "productId": 516765
-  },
-  {
-    "productName": "Sasaki",
-    "setName": [
       "Super Pre Release Starter Deck 4 Animal Kingdom Pirates"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.47,
-    "lowestPriceWithShipping": 0.28,
+    "marketPrice": 0.57,
+    "lowestPriceWithShipping": 0.25,
     "color": [
       "Purple"
     ],
@@ -32440,13 +33719,38 @@
   {
     "productName": "Sasaki",
     "setName": [
+      "Kingdoms of Intrigue"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "marketPrice": 0.14,
+    "lowestPriceWithShipping": 0.04,
+    "color": [
+      "Blue"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "Animal Kingdom Pirates"
+    ],
+    "number": "OP04-048",
+    "productId": 516765
+  },
+  {
+    "productName": "Sasaki",
+    "setName": [
       "Kingdoms of Intrigue Pre Release Cards"
     ],
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 10.1,
-    "lowestPriceWithShipping": 9,
+    "marketPrice": 10.65,
+    "lowestPriceWithShipping": 15.63,
     "color": [
       "Blue"
     ],
@@ -32470,7 +33774,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.14,
+    "marketPrice": 0.12,
     "lowestPriceWithShipping": 0.04,
     "color": [
       "Purple"
@@ -32495,8 +33799,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.52,
-    "lowestPriceWithShipping": 0.18,
+    "marketPrice": 0.29,
+    "lowestPriceWithShipping": 0.14,
     "color": [
       "Purple"
     ],
@@ -32513,6 +33817,54 @@
     "productId": 454636
   },
   {
+    "productName": "Sasaki (CS 2023 Event Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "marketPrice": 21.58,
+    "lowestPriceWithShipping": 13.82,
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Animal Kingdom Pirates"
+    ],
+    "number": "OP01-101",
+    "productId": 525296
+  },
+  {
+    "productName": "Sasaki (CS 2023 Event Pack Finalist Ver.)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Animal Kingdom Pirates"
+    ],
+    "number": "OP01-101",
+    "productId": 525694
+  },
+  {
     "productName": "Sasaki (Event Pack Vol. 2)",
     "setName": [
       "One Piece Promotion Cards"
@@ -32520,8 +33872,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 3.61,
-    "lowestPriceWithShipping": 3.19,
+    "marketPrice": 3.44,
+    "lowestPriceWithShipping": 1.95,
     "color": [
       "Purple"
     ],
@@ -32545,8 +33897,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.68,
-    "lowestPriceWithShipping": 0.35,
+    "marketPrice": 0.87,
+    "lowestPriceWithShipping": 0.4,
     "color": [
       "Yellow"
     ],
@@ -32571,8 +33923,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.81,
-    "lowestPriceWithShipping": 0.6,
+    "marketPrice": 0.73,
+    "lowestPriceWithShipping": 0.59,
     "color": [
       "Green"
     ],
@@ -32595,8 +33947,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.19,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.25,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Green"
     ],
@@ -32646,8 +33998,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.02,
-    "lowestPriceWithShipping": 0.75,
+    "marketPrice": 2.01,
+    "lowestPriceWithShipping": 2.9,
     "color": [
       "Green"
     ],
@@ -32672,7 +34024,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.15,
+    "marketPrice": 0.14,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Purple"
@@ -32698,8 +34050,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.55,
-    "lowestPriceWithShipping": 0.25,
+    "marketPrice": 1.88,
+    "lowestPriceWithShipping": 1.6,
     "color": [
       "Green"
     ],
@@ -32724,8 +34076,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 67.52,
-    "lowestPriceWithShipping": 69.47,
+    "marketPrice": 69.57,
+    "lowestPriceWithShipping": 74.97,
     "number": null,
     "productId": 518704
   },
@@ -32737,8 +34089,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.23,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.22,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Red"
     ],
@@ -32761,8 +34113,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.19,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.18,
+    "lowestPriceWithShipping": 0.09,
     "color": [
       "Black"
     ],
@@ -32786,7 +34138,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.16,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Black"
@@ -32804,6 +34156,31 @@
     "productId": 486321
   },
   {
+    "productName": "Sengoku (CS 2023 Event Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 21.62,
+    "lowestPriceWithShipping": 12.4,
+    "color": [
+      "Black"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Wisdom"
+    ],
+    "subtypes": [
+      "Navy"
+    ],
+    "number": "P-032",
+    "productId": 525303
+  },
+  {
     "productName": "Sengoku (Event Pack Vol. 1)",
     "setName": [
       "One Piece Promotion Cards"
@@ -32811,8 +34188,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 9.65,
-    "lowestPriceWithShipping": 17.99,
+    "marketPrice": 12.28,
+    "lowestPriceWithShipping": 11.39,
     "color": [
       "Black"
     ],
@@ -32836,7 +34213,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.13,
+    "marketPrice": 0.1,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -32861,8 +34238,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.68,
-    "lowestPriceWithShipping": 0.49,
+    "marketPrice": 0.57,
+    "lowestPriceWithShipping": 0.38,
     "color": [
       "Blue"
     ],
@@ -32886,8 +34263,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.58,
-    "lowestPriceWithShipping": 0.8,
+    "marketPrice": 2.06,
+    "lowestPriceWithShipping": 1.9,
     "color": [
       "Blue"
     ],
@@ -32911,7 +34288,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -32936,8 +34313,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.67,
-    "lowestPriceWithShipping": 0.66,
+    "marketPrice": 0.71,
+    "lowestPriceWithShipping": 0.65,
     "color": [
       "Black"
     ],
@@ -32954,6 +34331,31 @@
     "productId": 486675
   },
   {
+    "productName": "Sentomaru (CS 2023 Celebration Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 23.11,
+    "lowestPriceWithShipping": 15.9,
+    "color": [
+      "Blue"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Navy"
+    ],
+    "number": "ST03-007",
+    "productId": 525328
+  },
+  {
     "productName": "Sentomaru (Tournament Pack Vol. 3) [Participant]",
     "setName": [
       "One Piece Promotion Cards"
@@ -32961,8 +34363,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 0.53,
-    "lowestPriceWithShipping": 0.33,
+    "marketPrice": 0.46,
+    "lowestPriceWithShipping": 0.15,
     "color": [
       "Blue"
     ],
@@ -32986,8 +34388,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 6.26,
-    "lowestPriceWithShipping": 5.49,
+    "marketPrice": 9.47,
+    "lowestPriceWithShipping": 4.71,
     "color": [
       "Blue"
     ],
@@ -33011,8 +34413,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.05,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Green"
     ],
@@ -33036,8 +34438,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.12,
-    "lowestPriceWithShipping": 0.08,
+    "marketPrice": 0.17,
+    "lowestPriceWithShipping": 0.07,
     "color": [
       "Purple"
     ],
@@ -33061,8 +34463,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.85,
-    "lowestPriceWithShipping": 0.84,
+    "marketPrice": 0.93,
+    "lowestPriceWithShipping": 0.89,
     "color": [
       "Green"
     ],
@@ -33087,7 +34489,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -33113,8 +34515,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 19.66,
-    "lowestPriceWithShipping": 20.95,
+    "marketPrice": 22.45,
+    "lowestPriceWithShipping": 19.99,
     "color": [
       "Red"
     ],
@@ -33139,8 +34541,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 2.11,
-    "lowestPriceWithShipping": 1.49,
+    "marketPrice": 1.61,
+    "lowestPriceWithShipping": 1.4,
     "color": [
       "Black"
     ],
@@ -33164,8 +34566,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.61,
-    "lowestPriceWithShipping": 0.99,
+    "marketPrice": 4.53,
+    "lowestPriceWithShipping": 3,
     "color": [
       "Purple"
     ],
@@ -33191,8 +34593,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 0.66,
-    "lowestPriceWithShipping": 0.48,
+    "marketPrice": 0.64,
+    "lowestPriceWithShipping": 0.49,
     "color": [
       "Red"
     ],
@@ -33218,8 +34620,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 36.35,
-    "lowestPriceWithShipping": 38.99,
+    "marketPrice": 64.69,
+    "lowestPriceWithShipping": 48.9,
     "color": [
       "Red"
     ],
@@ -33244,8 +34646,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 1089.8,
-    "lowestPriceWithShipping": 1995.55,
+    "marketPrice": 1534.26,
+    "lowestPriceWithShipping": 2529.98,
     "color": [
       "Red"
     ],
@@ -33270,8 +34672,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.61,
-    "lowestPriceWithShipping": 1.36,
+    "marketPrice": 1.9,
+    "lowestPriceWithShipping": 1.87,
     "color": [
       "Red"
     ],
@@ -33297,8 +34699,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 7.97,
-    "lowestPriceWithShipping": 9.59,
+    "marketPrice": 13.21,
+    "lowestPriceWithShipping": 11.6,
     "color": [
       "Blue"
     ],
@@ -33322,8 +34724,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.03,
+    "marketPrice": 0.17,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Purple"
     ],
@@ -33341,38 +34743,12 @@
   {
     "productName": "Sheepshead",
     "setName": [
-      "Starter Deck 4 Animal Kingdom Pirates"
-    ],
-    "rarityName": [
-      "Common"
-    ],
-    "marketPrice": 0.11,
-    "lowestPriceWithShipping": 0.02,
-    "color": [
-      "Purple"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Slash"
-    ],
-    "subtypes": [
-      "Animal Kingdom Pirates",
-      "SMILE"
-    ],
-    "number": "ST04-007",
-    "productId": 288283
-  },
-  {
-    "productName": "Sheepshead",
-    "setName": [
       "Super Pre Release Starter Deck 4 Animal Kingdom Pirates"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.21,
+    "marketPrice": 0.18,
     "lowestPriceWithShipping": 0.1,
     "color": [
       "Purple"
@@ -33391,6 +34767,32 @@
     "productId": 424674
   },
   {
+    "productName": "Sheepshead",
+    "setName": [
+      "Starter Deck 4 Animal Kingdom Pirates"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 0.09,
+    "lowestPriceWithShipping": 0.02,
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Animal Kingdom Pirates",
+      "SMILE"
+    ],
+    "number": "ST04-007",
+    "productId": 288283
+  },
+  {
     "productName": "Shiki",
     "setName": [
       "Paramount War"
@@ -33398,8 +34800,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.5,
-    "lowestPriceWithShipping": 0.25,
+    "marketPrice": 0.34,
+    "lowestPriceWithShipping": 0.2,
     "color": [
       "Purple"
     ],
@@ -33424,7 +34826,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.3,
+    "marketPrice": 0.27,
     "lowestPriceWithShipping": 0.09,
     "color": [
       "Purple"
@@ -33450,8 +34852,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 3.12,
-    "lowestPriceWithShipping": 2.15,
+    "marketPrice": 4.41,
+    "lowestPriceWithShipping": 4.8,
     "color": [
       "Purple"
     ],
@@ -33476,7 +34878,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.1,
+    "marketPrice": 0.14,
     "lowestPriceWithShipping": 0.07,
     "color": [
       "Yellow"
@@ -33501,7 +34903,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.04,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -33527,7 +34929,7 @@
       "Common"
     ],
     "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.01,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Yellow"
     ],
@@ -33551,8 +34953,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.48,
-    "lowestPriceWithShipping": 0.23,
+    "marketPrice": 0.66,
+    "lowestPriceWithShipping": 0.5,
     "color": [
       "Yellow"
     ],
@@ -33576,8 +34978,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 13.13,
-    "lowestPriceWithShipping": 13.12,
+    "marketPrice": 12.38,
+    "lowestPriceWithShipping": 9.94,
     "color": [
       "Yellow"
     ],
@@ -33601,8 +35003,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.19,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.1,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Black"
     ],
@@ -33626,8 +35028,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.39,
-    "lowestPriceWithShipping": 0.25,
+    "marketPrice": 0.45,
+    "lowestPriceWithShipping": 0.23,
     "color": [
       "Black"
     ],
@@ -33651,8 +35053,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 16.15,
-    "lowestPriceWithShipping": 14.94,
+    "marketPrice": 7.03,
+    "lowestPriceWithShipping": 7.05,
     "color": [
       "Yellow"
     ],
@@ -33676,8 +35078,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 3.22,
-    "lowestPriceWithShipping": 7.85,
+    "marketPrice": 3.9,
+    "lowestPriceWithShipping": 6,
     "color": [
       "Yellow"
     ],
@@ -33701,7 +35103,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.1,
+    "marketPrice": 0.13,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Yellow"
@@ -33726,7 +35128,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.11,
+    "marketPrice": 0.12,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Purple"
@@ -33751,8 +35153,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.45,
-    "lowestPriceWithShipping": 0.37,
+    "marketPrice": 0.54,
+    "lowestPriceWithShipping": 0.43,
     "color": [
       "Green"
     ],
@@ -33776,7 +35178,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Green"
@@ -33801,8 +35203,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.85,
-    "lowestPriceWithShipping": 1.45,
+    "marketPrice": 1.45,
+    "lowestPriceWithShipping": 1.2,
     "color": [
       "Black"
     ],
@@ -33824,8 +35226,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.23,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.36,
+    "lowestPriceWithShipping": 0.15,
     "color": [
       "Yellow"
     ],
@@ -33850,8 +35252,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.23,
-    "lowestPriceWithShipping": 0.08,
+    "marketPrice": 0.24,
+    "lowestPriceWithShipping": 0.06,
     "color": [
       "Black"
     ],
@@ -33899,8 +35301,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.21,
-    "lowestPriceWithShipping": 0.98,
+    "marketPrice": 1.46,
+    "lowestPriceWithShipping": 1.29,
     "color": [
       "Black"
     ],
@@ -33924,7 +35326,7 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.25,
+    "marketPrice": 0.22,
     "lowestPriceWithShipping": 0.1,
     "color": [
       "Black"
@@ -33949,8 +35351,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 94.51,
-    "lowestPriceWithShipping": 90,
+    "marketPrice": 121.18,
+    "lowestPriceWithShipping": 109.1,
     "color": [
       "Black"
     ],
@@ -33974,7 +35376,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.19,
+    "marketPrice": 0.23,
     "lowestPriceWithShipping": 0.1,
     "color": [
       "Black"
@@ -33999,8 +35401,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.94,
-    "lowestPriceWithShipping": 1.5,
+    "marketPrice": 1.71,
+    "lowestPriceWithShipping": 1.86,
     "color": [
       "Black"
     ],
@@ -34024,8 +35426,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 47.92,
-    "lowestPriceWithShipping": 43.98,
+    "marketPrice": 63.77,
+    "lowestPriceWithShipping": 55,
     "color": [
       "Black"
     ],
@@ -34049,7 +35451,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.13,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -34072,8 +35474,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.73,
-    "lowestPriceWithShipping": 0.41,
+    "marketPrice": 4.29,
+    "lowestPriceWithShipping": 4.21,
     "color": [
       "Black"
     ],
@@ -34095,8 +35497,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 9.61,
-    "lowestPriceWithShipping": 8.76,
+    "marketPrice": 7.89,
+    "lowestPriceWithShipping": 7.94,
     "color": [
       "Blue"
     ],
@@ -34120,8 +35522,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 17.65,
-    "lowestPriceWithShipping": 16.25,
+    "marketPrice": 24.49,
+    "lowestPriceWithShipping": 22,
     "color": [
       "Blue"
     ],
@@ -34145,8 +35547,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 502.46,
-    "lowestPriceWithShipping": 650,
+    "marketPrice": 661.62,
+    "lowestPriceWithShipping": 699.01,
     "color": [
       "Blue"
     ],
@@ -34170,8 +35572,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.07,
-    "lowestPriceWithShipping": 0.95,
+    "marketPrice": 1.12,
+    "lowestPriceWithShipping": 1.1,
     "color": [
       "Purple"
     ],
@@ -34195,7 +35597,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -34221,8 +35623,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.23,
-    "lowestPriceWithShipping": 0.12,
+    "marketPrice": 0.62,
+    "lowestPriceWithShipping": 0.24,
     "color": [
       "Yellow"
     ],
@@ -34245,8 +35647,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.19,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.26,
+    "lowestPriceWithShipping": 0.11,
     "color": [
       "Black"
     ],
@@ -34270,8 +35672,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 7.33,
-    "lowestPriceWithShipping": 8,
+    "marketPrice": 17.56,
+    "lowestPriceWithShipping": 13.9,
     "color": [
       "Black"
     ],
@@ -34295,8 +35697,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 32.99,
-    "lowestPriceWithShipping": 34.98,
+    "marketPrice": 37.83,
+    "lowestPriceWithShipping": 73,
     "color": [
       "Black"
     ],
@@ -34320,8 +35722,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 13.58,
-    "lowestPriceWithShipping": 14,
+    "marketPrice": 18.17,
+    "lowestPriceWithShipping": 24.99,
     "color": [
       "Black"
     ],
@@ -34368,8 +35770,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 28.6,
-    "lowestPriceWithShipping": 29.95,
+    "marketPrice": 32.32,
+    "lowestPriceWithShipping": 99.95,
     "color": [
       "Black"
     ],
@@ -34393,8 +35795,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 16.63,
-    "lowestPriceWithShipping": 15.29,
+    "marketPrice": 17.94,
+    "lowestPriceWithShipping": 42,
     "color": [
       "Black"
     ],
@@ -34441,10 +35843,23 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 4.51,
-    "lowestPriceWithShipping": 3.5,
+    "marketPrice": 4.31,
+    "lowestPriceWithShipping": 3.95,
     "number": null,
     "productId": 521201
+  },
+  {
+    "productName": "Special DON!! Card Pack DP-02",
+    "setName": [
+      "Awakening of the New Era"
+    ],
+    "rarityName": [
+      "None"
+    ],
+    "marketPrice": 2.36,
+    "lowestPriceWithShipping": 2.36,
+    "number": null,
+    "productId": 531974
   },
   {
     "productName": "Speed",
@@ -34454,8 +35869,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.06,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Purple"
     ],
@@ -34480,7 +35895,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.05,
+    "marketPrice": 0.8,
     "lowestPriceWithShipping": 0.4,
     "color": [
       "Red"
@@ -34505,7 +35920,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -34530,8 +35945,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.5,
-    "lowestPriceWithShipping": 0.25,
+    "marketPrice": 0.46,
+    "lowestPriceWithShipping": 0.24,
     "color": [
       "Red"
     ],
@@ -34555,8 +35970,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.2,
-    "lowestPriceWithShipping": 10,
+    "marketPrice": 3.68,
+    "lowestPriceWithShipping": 3.6,
     "color": [
       "Purple"
     ],
@@ -34582,7 +35997,7 @@
       "Common"
     ],
     "marketPrice": 0.08,
-    "lowestPriceWithShipping": 0.01,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Purple"
     ],
@@ -34607,8 +36022,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.27,
-    "lowestPriceWithShipping": 0.06,
+    "marketPrice": 0.22,
+    "lowestPriceWithShipping": 0.19,
     "color": [
       "Green"
     ],
@@ -34631,7 +36046,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.5,
+    "marketPrice": 0.53,
     "lowestPriceWithShipping": 0.39,
     "color": [
       "Red"
@@ -34656,7 +36071,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.11,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -34681,8 +36096,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.79,
-    "lowestPriceWithShipping": 0.5,
+    "marketPrice": 1.14,
+    "lowestPriceWithShipping": 0.99,
     "color": [
       "Red"
     ],
@@ -34706,8 +36121,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.03,
+    "marketPrice": 0.07,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
     ],
@@ -34731,8 +36146,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.91,
-    "lowestPriceWithShipping": 3.2,
+    "marketPrice": 3.14,
+    "lowestPriceWithShipping": 2.48,
     "color": [
       "Blue"
     ],
@@ -34756,8 +36171,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 26.48,
-    "lowestPriceWithShipping": 26.49,
+    "marketPrice": 29.7,
+    "lowestPriceWithShipping": 26,
     "number": null,
     "productId": 288221
   },
@@ -34769,8 +36184,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 139.96,
-    "lowestPriceWithShipping": 149.99,
+    "marketPrice": 142.47,
+    "lowestPriceWithShipping": 199.95,
     "number": null,
     "productId": 288222
   },
@@ -34782,8 +36197,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 22.68,
-    "lowestPriceWithShipping": 22.67,
+    "marketPrice": 19.47,
+    "lowestPriceWithShipping": 18.01,
     "number": null,
     "productId": 515294
   },
@@ -34795,8 +36210,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 140.47,
-    "lowestPriceWithShipping": 135.98,
+    "marketPrice": 133.86,
+    "lowestPriceWithShipping": 119.85,
     "number": null,
     "productId": 515296
   },
@@ -34812,6 +36227,40 @@
     "productId": 515297
   },
   {
+    "productName": "Starter Deck 12: Zoro and Sanji",
+    "setName": [
+      "Starter Deck 12 Zoro and Sanji"
+    ],
+    "rarityName": [
+      "None"
+    ],
+    "marketPrice": 49.99,
+    "number": null,
+    "productId": 536585
+  },
+  {
+    "productName": "Starter Deck 12: Zoro and Sanji Display",
+    "setName": [
+      "Starter Deck 12 Zoro and Sanji"
+    ],
+    "rarityName": [
+      "None"
+    ],
+    "number": null,
+    "productId": 536586
+  },
+  {
+    "productName": "Starter Deck 12: Zoro and Sanji Display Case",
+    "setName": [
+      "Starter Deck 12 Zoro and Sanji"
+    ],
+    "rarityName": [
+      "None"
+    ],
+    "number": null,
+    "productId": 536587
+  },
+  {
     "productName": "Starter Deck 2: Worst Generation",
     "setName": [
       "Starter Deck 2 Worst Generation"
@@ -34819,8 +36268,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 37.56,
-    "lowestPriceWithShipping": 43.5,
+    "marketPrice": 51.65,
+    "lowestPriceWithShipping": 54.88,
     "number": null,
     "productId": 288226
   },
@@ -34843,8 +36292,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 37.29,
-    "lowestPriceWithShipping": 37.99,
+    "marketPrice": 50.46,
+    "lowestPriceWithShipping": 46.76,
     "number": null,
     "productId": 288227
   },
@@ -34867,8 +36316,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 91.93,
-    "lowestPriceWithShipping": 92.73,
+    "marketPrice": 106.5,
+    "lowestPriceWithShipping": 105,
     "number": null,
     "productId": 288224
   },
@@ -34891,8 +36340,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 47.59,
-    "lowestPriceWithShipping": 47.98,
+    "marketPrice": 49.97,
+    "lowestPriceWithShipping": 51.91,
     "number": null,
     "productId": 455859
   },
@@ -34904,7 +36353,7 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 150.12,
+    "marketPrice": 155.85,
     "lowestPriceWithShipping": 600,
     "number": null,
     "productId": 455860
@@ -34928,8 +36377,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 63.38,
-    "lowestPriceWithShipping": 64.48,
+    "marketPrice": 72.66,
+    "lowestPriceWithShipping": 72.97,
     "number": null,
     "productId": 455868
   },
@@ -34941,8 +36390,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 215.29,
-    "lowestPriceWithShipping": 449.99,
+    "marketPrice": 242.37,
+    "lowestPriceWithShipping": 449.98,
     "number": null,
     "productId": 455869
   },
@@ -34965,8 +36414,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 38.64,
-    "lowestPriceWithShipping": 47.99,
+    "marketPrice": 39.3,
+    "lowestPriceWithShipping": 42,
     "number": null,
     "productId": 480236
   },
@@ -34978,8 +36427,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 112.49,
-    "lowestPriceWithShipping": 270,
+    "marketPrice": 135.51,
+    "lowestPriceWithShipping": 230,
     "number": null,
     "productId": 480240
   },
@@ -34991,6 +36440,7 @@
     "rarityName": [
       "None"
     ],
+    "marketPrice": 0,
     "number": null,
     "productId": 480241
   },
@@ -35002,8 +36452,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 11.88,
-    "lowestPriceWithShipping": 12.99,
+    "marketPrice": 18.21,
+    "lowestPriceWithShipping": 18.29,
     "number": null,
     "productId": 502975
   },
@@ -35015,8 +36465,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 49.27,
-    "lowestPriceWithShipping": 49.98,
+    "marketPrice": 60.11,
+    "lowestPriceWithShipping": 118.96,
     "number": null,
     "productId": 502976
   },
@@ -35039,8 +36489,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 15.79,
-    "lowestPriceWithShipping": 17.23,
+    "marketPrice": 22.03,
+    "lowestPriceWithShipping": 17.97,
     "number": null,
     "productId": 502978
   },
@@ -35052,8 +36502,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 56.18,
-    "lowestPriceWithShipping": 51.99,
+    "marketPrice": 72.65,
+    "lowestPriceWithShipping": 136,
     "number": null,
     "productId": 502979
   },
@@ -35076,8 +36526,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 195.73,
-    "lowestPriceWithShipping": 199.49,
+    "marketPrice": 231.39,
+    "lowestPriceWithShipping": 244.98,
     "number": null,
     "productId": 288225
   },
@@ -35089,8 +36539,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 5.37,
-    "lowestPriceWithShipping": 3.92,
+    "marketPrice": 3.38,
+    "lowestPriceWithShipping": 2.3,
     "color": [
       "Black"
     ],
@@ -35139,8 +36589,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.11,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.1,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Green"
     ],
@@ -35162,8 +36612,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 9.47,
-    "lowestPriceWithShipping": 9.83,
+    "marketPrice": 7.98,
+    "lowestPriceWithShipping": 9.33,
     "color": [
       "Green"
     ],
@@ -35185,8 +36635,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.26,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.46,
+    "lowestPriceWithShipping": 0.39,
     "color": [
       "Green"
     ],
@@ -35209,8 +36659,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.61,
-    "lowestPriceWithShipping": 0.5,
+    "marketPrice": 0.86,
+    "lowestPriceWithShipping": 1.45,
     "color": [
       "Green"
     ],
@@ -35233,8 +36683,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.58,
-    "lowestPriceWithShipping": 0.57,
+    "marketPrice": 0.67,
+    "lowestPriceWithShipping": 0.61,
     "color": [
       "Black"
     ],
@@ -35258,7 +36708,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -35283,8 +36733,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.51,
-    "lowestPriceWithShipping": 0.19,
+    "marketPrice": 0.48,
+    "lowestPriceWithShipping": 0.18,
     "color": [
       "Yellow"
     ],
@@ -35308,8 +36758,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.31,
-    "lowestPriceWithShipping": 1.75,
+    "marketPrice": 2.15,
+    "lowestPriceWithShipping": 1.69,
     "color": [
       "Red"
     ],
@@ -35331,7 +36781,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -35349,37 +36799,12 @@
   {
     "productName": "Stussy",
     "setName": [
-      "Kingdoms of Intrigue Pre Release Cards"
-    ],
-    "rarityName": [
-      "Common"
-    ],
-    "marketPrice": 0.99,
-    "lowestPriceWithShipping": 0.75,
-    "color": [
-      "Black"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Special"
-    ],
-    "subtypes": [
-      "CP0"
-    ],
-    "number": "OP04-084",
-    "productId": 516886
-  },
-  {
-    "productName": "Stussy",
-    "setName": [
       "Kingdoms of Intrigue"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.1,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -35397,6 +36822,31 @@
     "productId": 516796
   },
   {
+    "productName": "Stussy",
+    "setName": [
+      "Kingdoms of Intrigue Pre Release Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 0.95,
+    "lowestPriceWithShipping": 0.75,
+    "color": [
+      "Black"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Special"
+    ],
+    "subtypes": [
+      "CP0"
+    ],
+    "number": "OP04-084",
+    "productId": 516886
+  },
+  {
     "productName": "Sugar",
     "setName": [
       "Kingdoms of Intrigue"
@@ -35404,8 +36854,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.48,
-    "lowestPriceWithShipping": 1.19,
+    "marketPrice": 1.52,
+    "lowestPriceWithShipping": 0.9,
     "color": [
       "Green"
     ],
@@ -35429,8 +36879,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 13.95,
-    "lowestPriceWithShipping": 13.51,
+    "marketPrice": 14.4,
+    "lowestPriceWithShipping": 14.4,
     "color": [
       "Green"
     ],
@@ -35454,7 +36904,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -35479,8 +36929,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.96,
-    "lowestPriceWithShipping": 0.9,
+    "marketPrice": 3.32,
+    "lowestPriceWithShipping": 16.94,
     "color": [
       "Black"
     ],
@@ -35504,8 +36954,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 3.64,
-    "lowestPriceWithShipping": 3.97,
+    "marketPrice": 3.44,
+    "lowestPriceWithShipping": 3.2,
     "color": [
       "Red"
     ],
@@ -35530,8 +36980,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 203.24,
-    "lowestPriceWithShipping": 425,
+    "marketPrice": 222.51,
+    "lowestPriceWithShipping": 379.49,
     "number": null,
     "productId": 409506
   },
@@ -35543,6 +36993,7 @@
     "rarityName": [
       "None"
     ],
+    "lowestPriceWithShipping": 10000,
     "number": null,
     "productId": 409743
   },
@@ -35554,8 +37005,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 85.75,
-    "lowestPriceWithShipping": 127,
+    "marketPrice": 114.98,
+    "lowestPriceWithShipping": 277.01,
     "number": null,
     "productId": 408197
   },
@@ -35567,6 +37018,7 @@
     "rarityName": [
       "None"
     ],
+    "lowestPriceWithShipping": 10000,
     "number": null,
     "productId": 408957
   },
@@ -35578,8 +37030,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 94.07,
-    "lowestPriceWithShipping": 103.98,
+    "marketPrice": 115.11,
+    "lowestPriceWithShipping": 189.99,
     "number": null,
     "productId": 411279
   },
@@ -35591,6 +37043,7 @@
     "rarityName": [
       "None"
     ],
+    "lowestPriceWithShipping": 10000,
     "number": null,
     "productId": 412137
   },
@@ -35602,8 +37055,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 125.48,
-    "lowestPriceWithShipping": 200,
+    "marketPrice": 161.97,
+    "lowestPriceWithShipping": 151.96,
     "number": null,
     "productId": 422137
   },
@@ -35615,6 +37068,7 @@
     "rarityName": [
       "None"
     ],
+    "lowestPriceWithShipping": 10000,
     "number": null,
     "productId": 422760
   },
@@ -35626,8 +37080,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 550.19,
-    "lowestPriceWithShipping": 899.9,
+    "marketPrice": 634.55,
+    "lowestPriceWithShipping": 999,
     "number": null,
     "productId": 411372
   },
@@ -35639,7 +37093,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.1,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -35665,8 +37119,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 2.18,
-    "lowestPriceWithShipping": 1.69,
+    "marketPrice": 2.08,
+    "lowestPriceWithShipping": 1.17,
     "color": [
       "Red"
     ],
@@ -35692,7 +37146,7 @@
       "Common"
     ],
     "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.04,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Black"
     ],
@@ -35711,38 +37165,13 @@
   {
     "productName": "Tashigi",
     "setName": [
-      "Paramount War Pre Release Cards"
-    ],
-    "rarityName": [
-      "Common"
-    ],
-    "marketPrice": 1.17,
-    "lowestPriceWithShipping": 1.28,
-    "color": [
-      "Black"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Slash"
-    ],
-    "subtypes": [
-      "Navy"
-    ],
-    "number": "OP02-105",
-    "productId": 486688
-  },
-  {
-    "productName": "Tashigi",
-    "setName": [
       "Starter Deck 6 Absolute Justice"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.24,
-    "lowestPriceWithShipping": 0.86,
+    "marketPrice": 1.33,
+    "lowestPriceWithShipping": 1.15,
     "color": [
       "Black"
     ],
@@ -35761,13 +37190,38 @@
   {
     "productName": "Tashigi",
     "setName": [
+      "Paramount War Pre Release Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 1.71,
+    "lowestPriceWithShipping": 1.46,
+    "color": [
+      "Black"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Navy"
+    ],
+    "number": "OP02-105",
+    "productId": 486688
+  },
+  {
+    "productName": "Tashigi",
+    "setName": [
       "Paramount War"
     ],
     "rarityName": [
       "Common"
     ],
     "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.02,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Black"
     ],
@@ -35791,8 +37245,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.24,
-    "lowestPriceWithShipping": 3.75,
+    "marketPrice": 3.94,
+    "lowestPriceWithShipping": 3.65,
     "color": [
       "Black"
     ],
@@ -35809,6 +37263,31 @@
     "productId": 485244
   },
   {
+    "productName": "Tashigi (CS 2023 Celebration Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 77.68,
+    "lowestPriceWithShipping": 57,
+    "color": [
+      "Black"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Navy"
+    ],
+    "number": "ST06-006",
+    "productId": 525339
+  },
+  {
     "productName": "Tashigi (Tournament Pack Vol. 4)",
     "setName": [
       "One Piece Promotion Cards"
@@ -35816,8 +37295,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.04,
-    "lowestPriceWithShipping": 0.86,
+    "marketPrice": 1.26,
+    "lowestPriceWithShipping": 1,
     "color": [
       "Black"
     ],
@@ -35841,8 +37320,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 34.58,
-    "lowestPriceWithShipping": 40,
+    "marketPrice": 31.39,
+    "lowestPriceWithShipping": 23.24,
     "color": [
       "Black"
     ],
@@ -35866,8 +37345,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.14,
-    "lowestPriceWithShipping": 0.03,
+    "marketPrice": 0.15,
+    "lowestPriceWithShipping": 0.09,
     "color": [
       "Black"
     ],
@@ -35889,8 +37368,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 4.3,
-    "lowestPriceWithShipping": 4.99,
+    "marketPrice": 5.03,
     "color": [
       "Black"
     ],
@@ -35912,7 +37390,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.1,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -35937,8 +37415,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 5.64,
-    "lowestPriceWithShipping": 6.9,
+    "marketPrice": 4.3,
+    "lowestPriceWithShipping": 4.25,
     "color": [
       "Red"
     ],
@@ -35962,8 +37440,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.51,
-    "lowestPriceWithShipping": 3.92,
+    "marketPrice": 1.73,
+    "lowestPriceWithShipping": 3,
     "color": [
       "Red"
     ],
@@ -35987,7 +37465,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Red"
@@ -36012,7 +37490,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -36036,8 +37514,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.14,
-    "lowestPriceWithShipping": 0.89,
+    "marketPrice": 1.13,
+    "lowestPriceWithShipping": 1,
     "color": [
       "Green"
     ],
@@ -36053,6 +37531,30 @@
     "productId": 516857
   },
   {
+    "productName": "The World's Continuation (Starter Deck 11: Uta Deck Battle)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 22.1,
+    "lowestPriceWithShipping": 22.38,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Event"
+    ],
+    "attribute": null,
+    "subtypes": [
+      "FILM",
+      "Music"
+    ],
+    "number": "P-059",
+    "productId": 532112
+  },
+  {
     "productName": "Thousand Sunny",
     "setName": [
       "Super Pre Release Starter Deck 1 Straw Hat Crew"
@@ -36060,8 +37562,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.79,
-    "lowestPriceWithShipping": 0.75,
+    "marketPrice": 0.77,
+    "lowestPriceWithShipping": 0.65,
     "color": [
       "Red"
     ],
@@ -36083,8 +37585,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.16,
-    "lowestPriceWithShipping": 0.03,
+    "marketPrice": 0.2,
+    "lowestPriceWithShipping": 0.07,
     "color": [
       "Red"
     ],
@@ -36106,8 +37608,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.49,
-    "lowestPriceWithShipping": 2.69,
+    "marketPrice": 2.63,
+    "lowestPriceWithShipping": 2.59,
     "color": [
       "Green"
     ],
@@ -36130,8 +37632,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.08,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Green"
     ],
@@ -36155,8 +37657,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 2.48,
-    "lowestPriceWithShipping": 1.99,
+    "marketPrice": 1.57,
+    "lowestPriceWithShipping": 1,
     "color": [
       "Blue"
     ],
@@ -36179,8 +37681,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 8.06,
-    "lowestPriceWithShipping": 6.98,
+    "marketPrice": 5.24,
+    "lowestPriceWithShipping": 5.34,
     "color": [
       "Blue"
     ],
@@ -36203,8 +37705,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.1,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Blue"
     ],
@@ -36251,7 +37753,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.22,
+    "marketPrice": 0.24,
     "lowestPriceWithShipping": 0.16,
     "color": [
       "Yellow"
@@ -36274,8 +37776,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 1.78,
-    "lowestPriceWithShipping": 1.25,
+    "marketPrice": 1.73,
+    "lowestPriceWithShipping": 1.44,
     "color": [
       "Purple"
     ],
@@ -36298,8 +37800,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 7.98,
-    "lowestPriceWithShipping": 7.6,
+    "marketPrice": 7.78,
+    "lowestPriceWithShipping": 7,
     "color": [
       "Yellow"
     ],
@@ -36322,8 +37824,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.16,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.21,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Yellow"
     ],
@@ -36346,8 +37848,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 15.65,
-    "lowestPriceWithShipping": 11.92,
+    "marketPrice": 4.43,
+    "lowestPriceWithShipping": 3.89,
     "color": [
       "Yellow"
     ],
@@ -36370,7 +37872,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -36396,8 +37898,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.7,
-    "lowestPriceWithShipping": 0.46,
+    "marketPrice": 0.67,
+    "lowestPriceWithShipping": 0.58,
     "color": [
       "Purple"
     ],
@@ -36422,8 +37924,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.03,
+    "marketPrice": 0.05,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
     ],
@@ -36447,8 +37949,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3,
-    "lowestPriceWithShipping": 2.99,
+    "marketPrice": 2.84,
+    "lowestPriceWithShipping": 2.2,
     "color": [
       "Red"
     ],
@@ -36472,7 +37974,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
@@ -36497,8 +37999,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.09,
-    "lowestPriceWithShipping": 0.96,
+    "marketPrice": 1.08,
+    "lowestPriceWithShipping": 0.75,
     "color": [
       "Yellow"
     ],
@@ -36522,7 +38024,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.41,
+    "marketPrice": 0.35,
     "lowestPriceWithShipping": 0.25,
     "color": [
       "Purple"
@@ -36548,7 +38050,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.03,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -36574,7 +38076,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.03,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
@@ -36599,8 +38101,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.78,
-    "lowestPriceWithShipping": 0.66,
+    "marketPrice": 0.83,
+    "lowestPriceWithShipping": 0.61,
     "color": [
       "Yellow"
     ],
@@ -36624,8 +38126,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.6,
-    "lowestPriceWithShipping": 0.35,
+    "marketPrice": 0.26,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Green"
     ],
@@ -36646,38 +38148,13 @@
   {
     "productName": "Tony Tony.Chopper",
     "setName": [
-      "Paramount War Pre Release Cards"
-    ],
-    "rarityName": [
-      "Uncommon"
-    ],
-    "marketPrice": 4.57,
-    "lowestPriceWithShipping": 3.17,
-    "color": [
-      "Green"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Wisdom"
-    ],
-    "subtypes": [
-      "Animal",
-      "Straw Hat Crew"
-    ],
-    "number": "OP02-034",
-    "productId": 486760
-  },
-  {
-    "productName": "Tony Tony.Chopper",
-    "setName": [
       "Kingdoms of Intrigue Pre Release Cards"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.64,
+    "marketPrice": 3.44,
+    "lowestPriceWithShipping": 5.91,
     "color": [
       "Red"
     ],
@@ -36698,12 +38175,38 @@
   {
     "productName": "Tony Tony.Chopper",
     "setName": [
+      "Paramount War Pre Release Cards"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "marketPrice": 3.42,
+    "lowestPriceWithShipping": 3.19,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Wisdom"
+    ],
+    "subtypes": [
+      "Animal",
+      "Straw Hat Crew"
+    ],
+    "number": "OP02-034",
+    "productId": 486760
+  },
+  {
+    "productName": "Tony Tony.Chopper",
+    "setName": [
       "Kingdoms of Intrigue"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.04,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -36730,8 +38233,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.04,
-    "lowestPriceWithShipping": 2.8,
+    "marketPrice": 2.71,
+    "lowestPriceWithShipping": 1.8,
     "color": [
       "Red"
     ],
@@ -36756,8 +38259,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.02,
-    "lowestPriceWithShipping": 0.6,
+    "marketPrice": 0.58,
+    "lowestPriceWithShipping": 0.3,
     "color": [
       "Red"
     ],
@@ -36782,8 +38285,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.09,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Red"
     ],
@@ -36808,8 +38311,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 12.7344,
-    "lowestPriceWithShipping": 11.5,
+    "marketPrice": 11.46,
+    "lowestPriceWithShipping": 10,
     "color": [
       "Red"
     ],
@@ -36834,8 +38337,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 246.49,
-    "lowestPriceWithShipping": 207.9,
+    "marketPrice": 245.23,
+    "lowestPriceWithShipping": 500,
     "color": [
       "Red"
     ],
@@ -36860,8 +38363,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 82.11,
-    "lowestPriceWithShipping": 90.75,
+    "marketPrice": 93.88,
+    "lowestPriceWithShipping": 146.92,
     "color": null,
     "cardType": [
       "Character"
@@ -36904,8 +38407,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 14.68,
-    "lowestPriceWithShipping": 14,
+    "marketPrice": 13.23,
+    "lowestPriceWithShipping": 12.69,
     "color": [
       "Red"
     ],
@@ -36930,8 +38433,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 8.1332,
-    "lowestPriceWithShipping": 8.16,
+    "marketPrice": 7.03,
+    "lowestPriceWithShipping": 6.9,
     "color": [
       "Red"
     ],
@@ -36956,8 +38459,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 26.31,
-    "lowestPriceWithShipping": 25.75,
+    "marketPrice": 33.89,
+    "lowestPriceWithShipping": 37.96,
     "color": [
       "Green"
     ],
@@ -36982,7 +38485,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.47,
+    "marketPrice": 0.45,
     "lowestPriceWithShipping": 0.35,
     "color": [
       "Green"
@@ -37007,7 +38510,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -37032,8 +38535,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.07,
+    "marketPrice": 0.18,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Purple"
     ],
@@ -37056,8 +38559,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 4.35,
-    "lowestPriceWithShipping": 4.9,
+    "marketPrice": 5.31,
+    "lowestPriceWithShipping": 5.21,
     "color": [
       "Purple"
     ],
@@ -37073,6 +38576,30 @@
     "productId": 501716
   },
   {
+    "productName": "Tot Musica (Starter Deck 11: Uta Deck Battle)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 9.56,
+    "lowestPriceWithShipping": 4.5,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Event"
+    ],
+    "attribute": null,
+    "subtypes": [
+      "FILM",
+      "Music"
+    ],
+    "number": "P-060",
+    "productId": 532113
+  },
+  {
     "productName": "Tournament Pack Vol. 1",
     "setName": [
       "One Piece Promotion Cards"
@@ -37080,8 +38607,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 5.11,
-    "lowestPriceWithShipping": 4.94,
+    "marketPrice": 5.94,
+    "lowestPriceWithShipping": 7,
     "number": null,
     "productId": 457013
   },
@@ -37093,8 +38620,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 1.54,
-    "lowestPriceWithShipping": 1.34,
+    "marketPrice": 2.12,
+    "lowestPriceWithShipping": 2.98,
     "number": null,
     "productId": 483112
   },
@@ -37106,8 +38633,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 3.05,
-    "lowestPriceWithShipping": 2.86,
+    "marketPrice": 2.57,
+    "lowestPriceWithShipping": 2.29,
     "number": null,
     "productId": 497007
   },
@@ -37119,8 +38646,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 1.35,
-    "lowestPriceWithShipping": 1.37,
+    "marketPrice": 1.92,
+    "lowestPriceWithShipping": 2.08,
     "number": null,
     "productId": 503251
   },
@@ -37132,36 +38659,10 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 4.74,
-    "lowestPriceWithShipping": 3.86,
+    "marketPrice": 2.38,
+    "lowestPriceWithShipping": 1.98,
     "number": null,
     "productId": 519829
-  },
-  {
-    "productName": "Trafalgar Law",
-    "setName": [
-      "Kingdoms of Intrigue Pre Release Cards"
-    ],
-    "rarityName": [
-      "Common"
-    ],
-    "marketPrice": 0.69,
-    "lowestPriceWithShipping": 0.5,
-    "color": [
-      "Black"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Slash"
-    ],
-    "subtypes": [
-      "Heart Pirates",
-      "Dressrosa"
-    ],
-    "number": "OP04-087",
-    "productId": 516889
   },
   {
     "productName": "Trafalgar Law",
@@ -37172,7 +38673,34 @@
       "Common"
     ],
     "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.02,
+    "lowestPriceWithShipping": 0.05,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Film",
+      "Heart Pirates",
+      "Supernovas"
+    ],
+    "number": "OP02-035",
+    "productId": 486355
+  },
+  {
+    "productName": "Trafalgar Law",
+    "setName": [
+      "Paramount War"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 0.1,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Green"
     ],
@@ -37198,8 +38726,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 2.51,
-    "lowestPriceWithShipping": 1.99,
+    "marketPrice": 3.9,
+    "lowestPriceWithShipping": 3.5,
     "color": [
       "Green"
     ],
@@ -37224,8 +38752,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 4.14,
-    "lowestPriceWithShipping": 2.99,
+    "marketPrice": 4.6,
+    "lowestPriceWithShipping": 5.65,
     "color": [
       "Green"
     ],
@@ -37250,7 +38778,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -37276,8 +38804,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 7.73,
-    "lowestPriceWithShipping": 7.43,
+    "marketPrice": 8.31,
+    "lowestPriceWithShipping": 7.86,
     "color": [
       "Green"
     ],
@@ -37302,8 +38830,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1,
-    "lowestPriceWithShipping": 0.9,
+    "marketPrice": 0.8,
+    "lowestPriceWithShipping": 0.48,
     "color": [
       "Blue"
     ],
@@ -37328,8 +38856,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.61,
-    "lowestPriceWithShipping": 1.54,
+    "marketPrice": 1.46,
+    "lowestPriceWithShipping": 1.38,
     "color": [
       "Blue"
     ],
@@ -37354,8 +38882,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 13.99,
-    "lowestPriceWithShipping": 16.49,
+    "marketPrice": 27.12,
+    "lowestPriceWithShipping": 21.91,
     "color": [
       "Blue"
     ],
@@ -37380,7 +38908,7 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.78,
+    "marketPrice": 0.95,
     "lowestPriceWithShipping": 0.49,
     "color": [
       "Purple",
@@ -37406,8 +38934,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 0.36,
-    "lowestPriceWithShipping": 0.24,
+    "marketPrice": 0.43,
+    "lowestPriceWithShipping": 0.38,
     "color": [
       "Green",
       "Red"
@@ -37433,8 +38961,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 334.39,
-    "lowestPriceWithShipping": 375.75,
+    "marketPrice": 422.69,
+    "lowestPriceWithShipping": 410,
     "color": [
       "Green",
       "Red"
@@ -37460,8 +38988,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 8.56,
-    "lowestPriceWithShipping": 8.49,
+    "marketPrice": 6.74,
+    "lowestPriceWithShipping": 7.25,
     "color": [
       "Purple"
     ],
@@ -37485,8 +39013,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.07,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Green"
     ],
@@ -37510,8 +39038,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 10.46,
-    "lowestPriceWithShipping": 9.98,
+    "marketPrice": 9.15,
+    "lowestPriceWithShipping": 35,
     "color": [
       "Green"
     ],
@@ -37535,8 +39063,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 19.08,
-    "lowestPriceWithShipping": 17.99,
+    "marketPrice": 18.73,
+    "lowestPriceWithShipping": 18.01,
     "color": [
       "Green"
     ],
@@ -37561,8 +39089,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 64.92,
-    "lowestPriceWithShipping": 64.83,
+    "marketPrice": 114.66,
+    "lowestPriceWithShipping": 90,
     "color": [
       "Green"
     ],
@@ -37587,8 +39115,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 0.95,
-    "lowestPriceWithShipping": 0.58,
+    "marketPrice": 0.75,
+    "lowestPriceWithShipping": 0.5,
     "color": [
       "Purple"
     ],
@@ -37612,8 +39140,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 715.66,
-    "lowestPriceWithShipping": 1299,
+    "marketPrice": 988.61,
+    "lowestPriceWithShipping": 950,
     "color": [
       "Purple"
     ],
@@ -37637,8 +39165,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 17.84,
-    "lowestPriceWithShipping": 17.63,
+    "marketPrice": 19.13,
+    "lowestPriceWithShipping": 18,
     "color": [
       "Purple"
     ],
@@ -37655,6 +39183,105 @@
     "productId": 527662
   },
   {
+    "productName": "Trafalgar Law (CS 2023 Celebration Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 18.26,
+    "lowestPriceWithShipping": 15.98,
+    "color": [
+      "Blue"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Heart Pirates",
+      "Supernovas"
+    ],
+    "number": "P-009",
+    "productId": 525319
+  },
+  {
+    "productName": "Trafalgar Law (CS 2023 Top Players Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "lowestPriceWithShipping": 7000,
+    "color": [
+      "Blue"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Heart Pirates",
+      "The Seven Warlords of the Sea"
+    ],
+    "number": "ST03-008",
+    "productId": 525686
+  },
+  {
+    "productName": "Trafalgar Law (CS 2023 Top Players Pack) [Finalist]",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "color": [
+      "Blue"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Heart Pirates",
+      "The Seven Warlords of the Sea"
+    ],
+    "number": "ST03-008",
+    "productId": 525687
+  },
+  {
+    "productName": "Trafalgar Law (CS 2023 Top Players Pack) [Winner]",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "color": [
+      "Blue"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Heart Pirates",
+      "The Seven Warlords of the Sea"
+    ],
+    "number": "ST03-008",
+    "productId": 525688
+  },
+  {
     "productName": "Trafalgar Law (Gift Collection 2023)",
     "setName": [
       "One Piece Promotion Cards"
@@ -37662,8 +39289,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 6.17,
-    "lowestPriceWithShipping": 5,
+    "marketPrice": 4.41,
+    "lowestPriceWithShipping": 3.9,
     "color": [
       "Blue"
     ],
@@ -37688,8 +39315,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 38.69,
-    "lowestPriceWithShipping": 56.99,
+    "marketPrice": 51.84,
+    "lowestPriceWithShipping": 85.5,
     "color": [
       "Green"
     ],
@@ -37714,8 +39341,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 41.43,
-    "lowestPriceWithShipping": 47.5,
+    "marketPrice": 49.09,
+    "lowestPriceWithShipping": 57.9,
     "color": [
       "Green"
     ],
@@ -37765,8 +39392,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 8.6,
-    "lowestPriceWithShipping": 8,
+    "marketPrice": 9.53,
+    "lowestPriceWithShipping": 9.99,
     "color": [
       "Red"
     ],
@@ -37792,8 +39419,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 46.41,
-    "lowestPriceWithShipping": 64,
+    "marketPrice": 55.65,
+    "lowestPriceWithShipping": 140,
     "color": [
       "Green"
     ],
@@ -37818,8 +39445,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 38.86,
-    "lowestPriceWithShipping": 31.98,
+    "marketPrice": 40.82,
+    "lowestPriceWithShipping": 54.9,
     "color": [
       "Green"
     ],
@@ -37868,8 +39495,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 63.57,
-    "lowestPriceWithShipping": 62.96,
+    "marketPrice": 95.09,
+    "lowestPriceWithShipping": 85,
     "color": [
       "Green"
     ],
@@ -37894,8 +39521,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 6.42,
-    "lowestPriceWithShipping": 6,
+    "marketPrice": 4.32,
+    "lowestPriceWithShipping": 4,
     "color": [
       "Blue"
     ],
@@ -37920,7 +39547,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.14,
+    "marketPrice": 0.09,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Green"
@@ -37945,8 +39572,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 5.97,
-    "lowestPriceWithShipping": 5.97,
+    "marketPrice": 5.63,
+    "lowestPriceWithShipping": 5,
     "color": [
       "Green"
     ],
@@ -37970,7 +39597,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.09,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Yellow"
@@ -37993,8 +39620,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.68,
-    "lowestPriceWithShipping": 0.5,
+    "marketPrice": 0.69,
+    "lowestPriceWithShipping": 0.69,
     "color": [
       "Yellow"
     ],
@@ -38016,8 +39643,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.2,
-    "lowestPriceWithShipping": 0.08,
+    "marketPrice": 0.16,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Black"
     ],
@@ -38039,8 +39666,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 9.66,
-    "lowestPriceWithShipping": 9.92,
+    "marketPrice": 7.89,
+    "lowestPriceWithShipping": 7,
     "color": [
       "Black"
     ],
@@ -38064,8 +39691,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 2.29,
-    "lowestPriceWithShipping": 1.99,
+    "marketPrice": 1.88,
+    "lowestPriceWithShipping": 1.8,
     "color": [
       "Black"
     ],
@@ -38089,8 +39716,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.03,
+    "marketPrice": 0.12,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Black"
     ],
@@ -38107,6 +39734,31 @@
     "productId": 486322
   },
   {
+    "productName": "Tsuru (CS 2023 Event Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Uncommon"
+    ],
+    "marketPrice": 87.22,
+    "lowestPriceWithShipping": 78,
+    "color": [
+      "Black"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Wisdom"
+    ],
+    "subtypes": [
+      "Navy"
+    ],
+    "number": "OP02-106",
+    "productId": 525297
+  },
+  {
     "productName": "Tsuru (Event Pack Vol. 2)",
     "setName": [
       "One Piece Promotion Cards"
@@ -38114,8 +39766,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 17.68,
-    "lowestPriceWithShipping": 14.45,
+    "marketPrice": 22.29,
+    "lowestPriceWithShipping": 16.99,
     "color": [
       "Black"
     ],
@@ -38139,8 +39791,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.19,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.25,
+    "lowestPriceWithShipping": 0.13,
     "color": [
       "Yellow"
     ],
@@ -38162,8 +39814,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.7,
-    "lowestPriceWithShipping": 1.35,
+    "marketPrice": 1.45,
+    "lowestPriceWithShipping": 1.2,
     "color": [
       "Purple"
     ],
@@ -38212,8 +39864,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.26,
-    "lowestPriceWithShipping": 0.09,
+    "marketPrice": 0.3,
+    "lowestPriceWithShipping": 0.14,
     "color": [
       "Purple"
     ],
@@ -38232,37 +39884,12 @@
   {
     "productName": "Ulti",
     "setName": [
-      "Awakening of the New Era"
-    ],
-    "rarityName": [
-      "Super Rare"
-    ],
-    "marketPrice": 1.34,
-    "lowestPriceWithShipping": 0.94,
-    "color": [
-      "Blue"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Strike"
-    ],
-    "subtypes": [
-      "Animal Kingdom Pirates"
-    ],
-    "number": "OP05-043",
-    "productId": 527793
-  },
-  {
-    "productName": "Ulti",
-    "setName": [
       "Starter Deck 9 Yamato"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.11,
+    "marketPrice": 0.13,
     "lowestPriceWithShipping": 0.1,
     "color": [
       "Yellow"
@@ -38282,12 +39909,37 @@
   {
     "productName": "Ulti",
     "setName": [
+      "Awakening of the New Era"
+    ],
+    "rarityName": [
+      "Super Rare"
+    ],
+    "marketPrice": 0.78,
+    "lowestPriceWithShipping": 0.47,
+    "color": [
+      "Blue"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "Animal Kingdom Pirates"
+    ],
+    "number": "OP05-043",
+    "productId": 527793
+  },
+  {
+    "productName": "Ulti",
+    "setName": [
       "Super Pre Release Starter Deck 4 Animal Kingdom Pirates"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.48,
+    "marketPrice": 3.66,
     "lowestPriceWithShipping": 3,
     "color": [
       "Purple"
@@ -38312,8 +39964,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 16.41,
-    "lowestPriceWithShipping": 17.98,
+    "marketPrice": 22.81,
+    "lowestPriceWithShipping": 20.49,
     "color": [
       "Blue"
     ],
@@ -38337,8 +39989,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.16,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.17,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Purple"
     ],
@@ -38360,8 +40012,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 27.13,
-    "lowestPriceWithShipping": 26.74,
+    "marketPrice": 30.61,
+    "lowestPriceWithShipping": 21.72,
     "color": [
       "Purple"
     ],
@@ -38385,8 +40037,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.5,
-    "lowestPriceWithShipping": 1.15,
+    "marketPrice": 1.17,
+    "lowestPriceWithShipping": 1.17,
     "color": [
       "Purple"
     ],
@@ -38410,8 +40062,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 34.5,
-    "lowestPriceWithShipping": 28.46,
+    "marketPrice": 36.01,
+    "lowestPriceWithShipping": 37.95,
     "number": null,
     "productId": 502982
   },
@@ -38423,8 +40075,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 169,
-    "lowestPriceWithShipping": 164.73,
+    "marketPrice": 168.36,
+    "lowestPriceWithShipping": 284.95,
     "number": null,
     "productId": 502983
   },
@@ -38437,7 +40089,7 @@
       "None"
     ],
     "marketPrice": 679.99,
-    "lowestPriceWithShipping": 899.99,
+    "lowestPriceWithShipping": 1994.99,
     "number": null,
     "productId": 502984
   },
@@ -38449,8 +40101,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.47,
-    "lowestPriceWithShipping": 0.2,
+    "marketPrice": 0.27,
+    "lowestPriceWithShipping": 0.16,
     "color": [
       "Purple"
     ],
@@ -38473,8 +40125,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.08,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Yellow"
     ],
@@ -38496,8 +40148,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 9.99,
-    "lowestPriceWithShipping": 5.97,
+    "marketPrice": 4.66,
+    "lowestPriceWithShipping": 9,
     "color": [
       "Yellow"
     ],
@@ -38519,8 +40171,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.04,
+    "marketPrice": 0.17,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Purple"
     ],
@@ -38544,7 +40196,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.41,
+    "marketPrice": 0.45,
     "lowestPriceWithShipping": 0.3,
     "color": [
       "Green"
@@ -38570,8 +40222,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.14,
-    "lowestPriceWithShipping": 0.07,
+    "marketPrice": 0.19,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Green"
     ],
@@ -38596,8 +40248,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 10.28,
-    "lowestPriceWithShipping": 18,
+    "marketPrice": 13.19,
+    "lowestPriceWithShipping": 19.99,
     "color": [
       "Purple"
     ],
@@ -38621,8 +40273,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.21,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.15,
+    "lowestPriceWithShipping": 0.06,
     "color": [
       "Purple"
     ],
@@ -38647,7 +40299,7 @@
       "Common"
     ],
     "marketPrice": 0.33,
-    "lowestPriceWithShipping": 0.2,
+    "lowestPriceWithShipping": 0.15,
     "color": [
       "Red"
     ],
@@ -38666,12 +40318,37 @@
   {
     "productName": "Usopp",
     "setName": [
+      "Romance Dawn"
+    ],
+    "rarityName": [
+      "Rare"
+    ],
+    "marketPrice": 0.23,
+    "lowestPriceWithShipping": 0.08,
+    "color": [
+      "Red"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Ranged"
+    ],
+    "subtypes": [
+      "Straw Hat Crew"
+    ],
+    "number": "OP01-004",
+    "productId": 454516
+  },
+  {
+    "productName": "Usopp",
+    "setName": [
       "Starter Deck 1 Straw Hat Crew"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.09,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -38691,38 +40368,13 @@
   {
     "productName": "Usopp",
     "setName": [
-      "Romance Dawn"
-    ],
-    "rarityName": [
-      "Rare"
-    ],
-    "marketPrice": 0.19,
-    "lowestPriceWithShipping": 0.09,
-    "color": [
-      "Red"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Ranged"
-    ],
-    "subtypes": [
-      "Straw Hat Crew"
-    ],
-    "number": "OP01-004",
-    "productId": 454516
-  },
-  {
-    "productName": "Usopp",
-    "setName": [
       "Paramount War Pre Release Cards"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 8.56,
-    "lowestPriceWithShipping": 8.74,
+    "marketPrice": 10.62,
+    "lowestPriceWithShipping": 17.992,
     "color": [
       "Green"
     ],
@@ -38746,7 +40398,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -38772,7 +40424,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.12,
+    "marketPrice": 0.1,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Green"
@@ -38798,8 +40450,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.21,
-    "lowestPriceWithShipping": 1.48,
+    "marketPrice": 1.83,
+    "lowestPriceWithShipping": 8.48,
     "color": [
       "Red"
     ],
@@ -38824,8 +40476,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 0.7,
-    "lowestPriceWithShipping": 0.25,
+    "marketPrice": 1.56,
+    "lowestPriceWithShipping": 1,
     "color": [
       "Blue"
     ],
@@ -38849,8 +40501,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 277.87,
-    "lowestPriceWithShipping": 290,
+    "marketPrice": 322.53,
+    "lowestPriceWithShipping": 2000,
     "color": [
       "Red"
     ],
@@ -38874,8 +40526,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 1.16,
-    "lowestPriceWithShipping": 1,
+    "marketPrice": 1.61,
+    "lowestPriceWithShipping": 1.25,
     "color": [
       "Red"
     ],
@@ -38899,8 +40551,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 208.2,
-    "lowestPriceWithShipping": 114.75,
+    "marketPrice": 115.31,
+    "lowestPriceWithShipping": 199.98,
     "color": [
       "Red"
     ],
@@ -38943,8 +40595,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 8.53,
-    "lowestPriceWithShipping": 8.2,
+    "marketPrice": 16.35,
+    "lowestPriceWithShipping": 14.96,
     "color": [
       "Blue"
     ],
@@ -38968,8 +40620,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.4,
-    "lowestPriceWithShipping": 0.38,
+    "marketPrice": 0.45,
+    "lowestPriceWithShipping": 0.43,
     "color": [
       "Red"
     ],
@@ -38993,8 +40645,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.81,
-    "lowestPriceWithShipping": 0.73,
+    "marketPrice": 1.27,
+    "lowestPriceWithShipping": 1.19,
     "color": [
       "Red"
     ],
@@ -39018,8 +40670,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 11.62,
-    "lowestPriceWithShipping": 15,
+    "marketPrice": 21.11,
+    "lowestPriceWithShipping": 29.99,
     "color": [
       "Blue"
     ],
@@ -39043,7 +40695,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.04,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
@@ -39068,8 +40720,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.44,
-    "lowestPriceWithShipping": 0.27,
+    "marketPrice": 0.49,
+    "lowestPriceWithShipping": 0.49,
     "color": [
       "Blue"
     ],
@@ -39093,7 +40745,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.1,
+    "marketPrice": 0.14,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Blue"
@@ -39117,8 +40769,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 3.77,
-    "lowestPriceWithShipping": 3.15,
+    "marketPrice": 3.44,
+    "lowestPriceWithShipping": 3.44,
     "color": [
       "Blue"
     ],
@@ -39136,36 +40788,13 @@
   {
     "productName": "Uta",
     "setName": [
-      "Paramount War"
-    ],
-    "rarityName": [
-      "Secret Rare"
-    ],
-    "marketPrice": 8.07,
-    "lowestPriceWithShipping": 7.99,
-    "color": [
-      "Purple"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Special"
-    ],
-    "subtypes": null,
-    "number": "OP02-120",
-    "productId": 482718
-  },
-  {
-    "productName": "Uta",
-    "setName": [
       "Romance Dawn"
     ],
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.26,
-    "lowestPriceWithShipping": 0.2,
+    "marketPrice": 0.36,
+    "lowestPriceWithShipping": 0.15,
     "color": [
       "Red"
     ],
@@ -39184,13 +40813,36 @@
   {
     "productName": "Uta",
     "setName": [
+      "Paramount War"
+    ],
+    "rarityName": [
+      "Secret Rare"
+    ],
+    "marketPrice": 7.96,
+    "lowestPriceWithShipping": 6.98,
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Special"
+    ],
+    "subtypes": null,
+    "number": "OP02-120",
+    "productId": 482718
+  },
+  {
+    "productName": "Uta",
+    "setName": [
       "Starter Deck 5 Film Edition"
     ],
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 14.38,
-    "lowestPriceWithShipping": 13.44,
+    "marketPrice": 11.88,
+    "lowestPriceWithShipping": 11.89,
     "color": [
       "Purple"
     ],
@@ -39214,7 +40866,7 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 1.18,
+    "marketPrice": 1.26,
     "lowestPriceWithShipping": 0.95,
     "color": [
       "Black"
@@ -39232,6 +40884,56 @@
     "productId": 503230
   },
   {
+    "productName": "Uta (001)",
+    "setName": [
+      "Starter Deck 11 Uta"
+    ],
+    "rarityName": [
+      "Leader"
+    ],
+    "marketPrice": 1.18,
+    "lowestPriceWithShipping": 0.83,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Leader"
+    ],
+    "attribute": [
+      "Special"
+    ],
+    "subtypes": [
+      "FILM"
+    ],
+    "number": "ST11-001",
+    "productId": 533879
+  },
+  {
+    "productName": "Uta (002)",
+    "setName": [
+      "Starter Deck 11 Uta"
+    ],
+    "rarityName": [
+      "Super Rare"
+    ],
+    "marketPrice": 6.69,
+    "lowestPriceWithShipping": 6.29,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Special"
+    ],
+    "subtypes": [
+      "FILM"
+    ],
+    "number": "ST11-002",
+    "productId": 533880
+  },
+  {
     "productName": "Uta (Alternate Art)",
     "setName": [
       "Paramount War"
@@ -39239,8 +40941,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 30.92,
-    "lowestPriceWithShipping": 26.99,
+    "marketPrice": 39.07,
+    "lowestPriceWithShipping": 30.98,
     "color": [
       "Purple"
     ],
@@ -39255,6 +40957,31 @@
     "productId": 483360
   },
   {
+    "productName": "Uta (CS 2023 Event Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 54.06,
+    "lowestPriceWithShipping": 33.91,
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Special"
+    ],
+    "subtypes": [
+      "FILM"
+    ],
+    "number": "P-031",
+    "productId": 525302
+  },
+  {
     "productName": "Uta (Demo Deck 2023)",
     "setName": [
       "One Piece Promotion Cards"
@@ -39262,7 +40989,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.72,
+    "marketPrice": 0.76,
     "lowestPriceWithShipping": 0.7,
     "color": [
       "Red"
@@ -39285,8 +41012,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 17.68,
-    "lowestPriceWithShipping": 16.99,
+    "marketPrice": 33.46,
+    "lowestPriceWithShipping": 25,
     "color": [
       "Purple"
     ],
@@ -39310,8 +41037,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 5.58,
-    "lowestPriceWithShipping": 4.95,
+    "marketPrice": 4.83,
+    "lowestPriceWithShipping": 3.84,
     "color": [
       "Red"
     ],
@@ -39335,8 +41062,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 0.61,
-    "lowestPriceWithShipping": 0.4,
+    "marketPrice": 0.64,
+    "lowestPriceWithShipping": 0.5,
     "color": [
       "Red"
     ],
@@ -39360,8 +41087,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 3.04,
-    "lowestPriceWithShipping": 3.04,
+    "marketPrice": 3.3,
+    "lowestPriceWithShipping": 2.95,
     "color": [
       "Red"
     ],
@@ -39385,8 +41112,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 77.74,
-    "lowestPriceWithShipping": 75,
+    "marketPrice": 128.36,
+    "lowestPriceWithShipping": 116,
     "color": [
       "Purple"
     ],
@@ -39410,8 +41137,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.1,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.12,
+    "lowestPriceWithShipping": 0.07,
     "color": [
       "Yellow"
     ],
@@ -39435,8 +41162,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.63,
-    "lowestPriceWithShipping": 0.45,
+    "marketPrice": 0.7,
+    "lowestPriceWithShipping": 0.9,
     "color": [
       "Purple"
     ],
@@ -39481,7 +41208,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
@@ -39509,7 +41236,7 @@
       "Rare"
     ],
     "marketPrice": 0.07,
-    "lowestPriceWithShipping": 0.02,
+    "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
     ],
@@ -39534,8 +41261,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 9.29,
-    "lowestPriceWithShipping": 17.85,
+    "marketPrice": 20.84,
+    "lowestPriceWithShipping": 50,
     "color": [
       "Black"
     ],
@@ -39560,8 +41287,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.16,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.55,
+    "lowestPriceWithShipping": 0.3,
     "color": [
       "Black"
     ],
@@ -39586,8 +41313,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.09,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.11,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Black"
     ],
@@ -39611,8 +41338,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.02,
-    "lowestPriceWithShipping": 1.69,
+    "marketPrice": 3.9,
+    "lowestPriceWithShipping": 12.99,
     "color": [
       "Green"
     ],
@@ -39636,8 +41363,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 7.02,
-    "lowestPriceWithShipping": 7.7,
+    "marketPrice": 9.51,
+    "lowestPriceWithShipping": 18,
     "color": [
       "Black"
     ],
@@ -39661,7 +41388,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.09,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -39686,8 +41413,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.59,
-    "lowestPriceWithShipping": 0.43,
+    "marketPrice": 0.41,
+    "lowestPriceWithShipping": 0.18,
     "color": [
       "Red"
     ],
@@ -39711,7 +41438,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.23,
+    "marketPrice": 0.21,
     "lowestPriceWithShipping": 0.1,
     "color": [
       "Green"
@@ -39761,7 +41488,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -39786,8 +41513,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.83,
-    "lowestPriceWithShipping": 0.68,
+    "marketPrice": 0.89,
+    "lowestPriceWithShipping": 0.8,
     "color": [
       "Green"
     ],
@@ -39811,8 +41538,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 2.03,
-    "lowestPriceWithShipping": 1.99,
+    "marketPrice": 2.26,
+    "lowestPriceWithShipping": 3,
     "color": [
       "Black"
     ],
@@ -39836,8 +41563,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.06,
-    "lowestPriceWithShipping": 0.02,
+    "marketPrice": 0.07,
+    "lowestPriceWithShipping": 0.03,
     "color": [
       "Black"
     ],
@@ -39861,7 +41588,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.04,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Purple"
@@ -39885,7 +41612,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.72,
+    "marketPrice": 0.71,
     "lowestPriceWithShipping": 0.63,
     "color": [
       "Purple"
@@ -39909,8 +41636,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.14,
-    "lowestPriceWithShipping": 0.05,
+    "marketPrice": 0.11,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Purple"
     ],
@@ -39925,6 +41652,30 @@
     "productId": 528636
   },
   {
+    "productName": "Where the Wind Blows (Starter Deck 11: Uta Deck Battle)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 67.96,
+    "lowestPriceWithShipping": 55,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Event"
+    ],
+    "attribute": null,
+    "subtypes": [
+      "FILM",
+      "Music"
+    ],
+    "number": "P-058",
+    "productId": 532114
+  },
+  {
     "productName": "White Out",
     "setName": [
       "Starter Deck 6 Absolute Justice"
@@ -39932,7 +41683,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.1,
+    "marketPrice": 0.12,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Black"
@@ -39955,8 +41706,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 4.5,
-    "lowestPriceWithShipping": 3.49,
+    "marketPrice": 3.8,
+    "lowestPriceWithShipping": 3.25,
     "color": [
       "Red"
     ],
@@ -39978,8 +41729,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.31,
-    "lowestPriceWithShipping": 0.1,
+    "marketPrice": 0.27,
+    "lowestPriceWithShipping": 0.2,
     "color": [
       "Red"
     ],
@@ -40001,7 +41752,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.11,
+    "marketPrice": 0.09,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Red"
@@ -40026,8 +41777,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.76,
-    "lowestPriceWithShipping": 0.57,
+    "marketPrice": 0.81,
+    "lowestPriceWithShipping": 0.55,
     "color": [
       "Red"
     ],
@@ -40052,7 +41803,7 @@
       "Rare"
     ],
     "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.03,
+    "lowestPriceWithShipping": 0.04,
     "color": [
       "Blue"
     ],
@@ -40076,7 +41827,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.1,
+    "marketPrice": 0.06,
     "lowestPriceWithShipping": 0.04,
     "color": [
       "Purple"
@@ -40101,8 +41852,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.16,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.17,
+    "lowestPriceWithShipping": 0.05,
     "color": [
       "Purple"
     ],
@@ -40127,8 +41878,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.52,
-    "lowestPriceWithShipping": 0.3,
+    "marketPrice": 0.44,
+    "lowestPriceWithShipping": 0.25,
     "color": [
       "Purple"
     ],
@@ -40153,8 +41904,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 10.25,
-    "lowestPriceWithShipping": 11,
+    "marketPrice": 11.73,
+    "lowestPriceWithShipping": 9.79,
     "color": [
       "Blue"
     ],
@@ -40178,8 +41929,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 1.19,
-    "lowestPriceWithShipping": 0.8,
+    "marketPrice": 1.92,
+    "lowestPriceWithShipping": 1.3,
     "color": [
       "Purple"
     ],
@@ -40196,6 +41947,31 @@
     "productId": 453522
   },
   {
+    "productName": "Who's.Who (CS 2023 Celebration Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 11.34,
+    "lowestPriceWithShipping": 6.8,
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Animal Kingdom Pirates"
+    ],
+    "number": "ST04-010",
+    "productId": 525332
+  },
+  {
     "productName": "Who's.Who (Tournament Pack Vol. 3) [Participant]",
     "setName": [
       "One Piece Promotion Cards"
@@ -40203,7 +41979,7 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 0.2,
+    "marketPrice": 0.31,
     "lowestPriceWithShipping": 0.08,
     "color": [
       "Purple"
@@ -40228,8 +42004,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 3.29,
-    "lowestPriceWithShipping": 1.99,
+    "marketPrice": 5.04,
+    "lowestPriceWithShipping": 3,
     "color": [
       "Purple"
     ],
@@ -40253,8 +42029,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 147.79,
-    "lowestPriceWithShipping": 159.99,
+    "marketPrice": 245.41,
+    "lowestPriceWithShipping": 244.41,
     "number": null,
     "productId": 515080
   },
@@ -40266,8 +42042,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 1399.62,
-    "lowestPriceWithShipping": 1699.97,
+    "marketPrice": 2440.14,
+    "lowestPriceWithShipping": 2598.97,
     "number": null,
     "productId": 515081
   },
@@ -40279,8 +42055,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 5.84,
-    "lowestPriceWithShipping": 5.8,
+    "marketPrice": 8.94,
+    "lowestPriceWithShipping": 9.15,
     "number": null,
     "productId": 515077
   },
@@ -40292,8 +42068,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 21.03,
-    "lowestPriceWithShipping": 44.95,
+    "marketPrice": 28.96,
+    "lowestPriceWithShipping": 42.25,
     "number": null,
     "productId": 457017
   },
@@ -40305,8 +42081,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 9.82,
-    "lowestPriceWithShipping": 10,
+    "marketPrice": 12.66,
+    "lowestPriceWithShipping": 19.98,
     "number": null,
     "productId": 483164
   },
@@ -40318,8 +42094,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 24.73,
-    "lowestPriceWithShipping": 23.99,
+    "marketPrice": 36.32,
+    "lowestPriceWithShipping": 35.99,
     "number": null,
     "productId": 497008
   },
@@ -40331,8 +42107,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 25.58,
-    "lowestPriceWithShipping": 27.99,
+    "marketPrice": 27.74,
+    "lowestPriceWithShipping": 27.95,
     "number": null,
     "productId": 503252
   },
@@ -40344,8 +42120,8 @@
     "rarityName": [
       "None"
     ],
-    "marketPrice": 25.99,
-    "lowestPriceWithShipping": 28,
+    "marketPrice": 25.42,
+    "lowestPriceWithShipping": 20,
     "number": null,
     "productId": 519831
   },
@@ -40357,7 +42133,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.11,
+    "marketPrice": 0.12,
     "lowestPriceWithShipping": 0.04,
     "color": [
       "Purple"
@@ -40382,7 +42158,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Green"
@@ -40407,7 +42183,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.05,
+    "marketPrice": 0.04,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Blue"
@@ -40432,8 +42208,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 2.06,
-    "lowestPriceWithShipping": 2,
+    "marketPrice": 1.58,
+    "lowestPriceWithShipping": 1.53,
     "color": [
       "Blue"
     ],
@@ -40457,8 +42233,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.17,
-    "lowestPriceWithShipping": 0.03,
+    "marketPrice": 0.52,
+    "lowestPriceWithShipping": 0.49,
     "color": [
       "Green"
     ],
@@ -40484,7 +42260,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.17,
+    "marketPrice": 0.16,
     "lowestPriceWithShipping": 0.05,
     "color": [
       "Blue"
@@ -40506,12 +42282,39 @@
   {
     "productName": "X.Drake",
     "setName": [
+      "Super Pre Release Starter Deck 4 Animal Kingdom Pirates"
+    ],
+    "rarityName": [
+      "Common"
+    ],
+    "marketPrice": 0.24,
+    "lowestPriceWithShipping": 0.25,
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Animal Kingdom Pirates",
+      "Drake Pirates",
+      "Navy"
+    ],
+    "number": "ST04-013",
+    "productId": 426012
+  },
+  {
+    "productName": "X.Drake",
+    "setName": [
       "Starter Deck 4 Animal Kingdom Pirates"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.13,
+    "marketPrice": 0.11,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Purple"
@@ -40533,40 +42336,13 @@
   {
     "productName": "X.Drake",
     "setName": [
-      "Super Pre Release Starter Deck 4 Animal Kingdom Pirates"
-    ],
-    "rarityName": [
-      "Common"
-    ],
-    "marketPrice": 0.27,
-    "lowestPriceWithShipping": 0.1,
-    "color": [
-      "Purple"
-    ],
-    "cardType": [
-      "Character"
-    ],
-    "attribute": [
-      "Slash"
-    ],
-    "subtypes": [
-      "Animal Kingdom Pirates",
-      "Drake Pirates",
-      "Navy"
-    ],
-    "number": "ST04-013",
-    "productId": 426012
-  },
-  {
-    "productName": "X.Drake",
-    "setName": [
       "Super Pre Release Starter Deck 2 Worst Generation"
     ],
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.22,
-    "lowestPriceWithShipping": 1.09,
+    "marketPrice": 1.08,
+    "lowestPriceWithShipping": 0.99,
     "color": [
       "Green"
     ],
@@ -40592,8 +42368,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 1.9836,
-    "lowestPriceWithShipping": 1.57,
+    "marketPrice": 2.41,
+    "lowestPriceWithShipping": 2.18,
     "color": [
       "Green"
     ],
@@ -40619,8 +42395,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 2.42,
-    "lowestPriceWithShipping": 2,
+    "marketPrice": 1.93,
+    "lowestPriceWithShipping": 1.38,
     "color": [
       "Purple"
     ],
@@ -40646,8 +42422,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 10.79,
-    "lowestPriceWithShipping": 11.99,
+    "marketPrice": 10.57,
+    "lowestPriceWithShipping": 10.94,
     "color": [
       "Blue"
     ],
@@ -40666,6 +42442,82 @@
     "productId": 528314
   },
   {
+    "productName": "X.Drake (CS 2023 Top Players Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Rare"
+    ],
+    "lowestPriceWithShipping": 2199.99,
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Animal Kingdom Pirates",
+      "Drake Pirates",
+      "Navy"
+    ],
+    "number": "OP01-114",
+    "productId": 525677
+  },
+  {
+    "productName": "X.Drake (CS 2023 Top Players Pack) [Finalist]",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Rare"
+    ],
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Animal Kingdom Pirates",
+      "Drake Pirates",
+      "Navy"
+    ],
+    "number": "OP01-114",
+    "productId": 525678
+  },
+  {
+    "productName": "X.Drake (CS 2023 Top Players Pack) [Winner]",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Rare"
+    ],
+    "color": [
+      "Purple"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Slash"
+    ],
+    "subtypes": [
+      "Animal Kingdom Pirates",
+      "Drake Pirates",
+      "Navy"
+    ],
+    "number": "OP01-114",
+    "productId": 525679
+  },
+  {
     "productName": "X.Drake (Judge Pack Vol. 2)",
     "setName": [
       "One Piece Promotion Cards"
@@ -40673,8 +42525,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 2.69,
-    "lowestPriceWithShipping": 2.25,
+    "marketPrice": 1.95,
+    "lowestPriceWithShipping": 0.9,
     "color": [
       "Green"
     ],
@@ -40700,8 +42552,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 4,
-    "lowestPriceWithShipping": 4,
+    "marketPrice": 3.09,
+    "lowestPriceWithShipping": 2.65,
     "color": [
       "Yellow"
     ],
@@ -40726,7 +42578,7 @@
       "Common"
     ],
     "marketPrice": 0.12,
-    "lowestPriceWithShipping": 0.06,
+    "lowestPriceWithShipping": 0.02,
     "color": [
       "Yellow"
     ],
@@ -40750,7 +42602,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.7,
+    "marketPrice": 0.76,
     "lowestPriceWithShipping": 0.45,
     "color": [
       "Black"
@@ -40775,7 +42627,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.03,
+    "marketPrice": 0.04,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -40800,8 +42652,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.41,
-    "lowestPriceWithShipping": 0.22,
+    "marketPrice": 0.48,
+    "lowestPriceWithShipping": 0.24,
     "color": [
       "Green"
     ],
@@ -40825,8 +42677,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 56.82,
-    "lowestPriceWithShipping": 58,
+    "marketPrice": 53.87,
+    "lowestPriceWithShipping": 49.38,
     "color": [
       "Green"
     ],
@@ -40850,8 +42702,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 6.44,
-    "lowestPriceWithShipping": 6.99,
+    "marketPrice": 5.81,
+    "lowestPriceWithShipping": 5.59,
     "color": [
       "Yellow"
     ],
@@ -40875,8 +42727,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 28.19,
-    "lowestPriceWithShipping": 49.98,
+    "marketPrice": 54.14,
+    "lowestPriceWithShipping": 43.98,
     "color": [
       "Green"
     ],
@@ -40900,8 +42752,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 1.91,
-    "lowestPriceWithShipping": 1.91,
+    "marketPrice": 2.17,
+    "lowestPriceWithShipping": 1.04,
     "color": [
       "Yellow"
     ],
@@ -40925,8 +42777,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.21,
-    "lowestPriceWithShipping": 0.12,
+    "marketPrice": 0.39,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Yellow"
     ],
@@ -40975,8 +42827,8 @@
     "rarityName": [
       "Super Rare"
     ],
-    "marketPrice": 65.94,
-    "lowestPriceWithShipping": 60,
+    "marketPrice": 72.23,
+    "lowestPriceWithShipping": 70.88,
     "color": [
       "Yellow"
     ],
@@ -40993,6 +42845,31 @@
     "productId": 515310
   },
   {
+    "productName": "Yamato (CS 2023 Celebration Pack)",
+    "setName": [
+      "One Piece Promotion Cards"
+    ],
+    "rarityName": [
+      "Promo"
+    ],
+    "marketPrice": 36.57,
+    "lowestPriceWithShipping": 29,
+    "color": [
+      "Green"
+    ],
+    "cardType": [
+      "Character"
+    ],
+    "attribute": [
+      "Strike"
+    ],
+    "subtypes": [
+      "Land of Wano"
+    ],
+    "number": "P-008",
+    "productId": 525317
+  },
+  {
     "productName": "Yamato (Gift Collection 2023)",
     "setName": [
       "One Piece Promotion Cards"
@@ -41000,8 +42877,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 7.79,
-    "lowestPriceWithShipping": 7,
+    "marketPrice": 9.56,
+    "lowestPriceWithShipping": 9.95,
     "color": [
       "Yellow"
     ],
@@ -41025,8 +42902,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 4.46,
-    "lowestPriceWithShipping": 5.93,
+    "marketPrice": 6.44,
+    "lowestPriceWithShipping": 4.01,
     "color": [
       "Green"
     ],
@@ -41050,8 +42927,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 112.74,
-    "lowestPriceWithShipping": 122,
+    "marketPrice": 164.95,
+    "lowestPriceWithShipping": 127.24,
     "color": [
       "Green"
     ],
@@ -41075,8 +42952,8 @@
     "rarityName": [
       "Secret Rare"
     ],
-    "marketPrice": 98.23,
-    "lowestPriceWithShipping": 90.99,
+    "marketPrice": 140.31,
+    "lowestPriceWithShipping": 131.7,
     "color": [
       "Green"
     ],
@@ -41100,8 +42977,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 4.04,
-    "lowestPriceWithShipping": 7.95,
+    "marketPrice": 3.04,
+    "lowestPriceWithShipping": 2.89,
     "color": [
       "Green"
     ],
@@ -41125,7 +43002,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.04,
+    "marketPrice": 0.05,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Black"
@@ -41148,8 +43025,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 1.05,
-    "lowestPriceWithShipping": 0.7,
+    "marketPrice": 1.07,
+    "lowestPriceWithShipping": 0.99,
     "color": [
       "Black"
     ],
@@ -41171,8 +43048,8 @@
     "rarityName": [
       "Promo"
     ],
-    "marketPrice": 0.53,
-    "lowestPriceWithShipping": 0.4,
+    "marketPrice": 0.54,
+    "lowestPriceWithShipping": 0.39,
     "color": [
       "Red"
     ],
@@ -41197,7 +43074,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.73,
+    "marketPrice": 0.71,
     "lowestPriceWithShipping": 0.5,
     "color": [
       "Purple"
@@ -41249,7 +43126,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.44,
+    "marketPrice": 0.49,
     "lowestPriceWithShipping": 0.37,
     "color": [
       "Blue"
@@ -41299,7 +43176,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.08,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Green"
@@ -41323,8 +43200,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.82,
-    "lowestPriceWithShipping": 0.68,
+    "marketPrice": 0.91,
+    "lowestPriceWithShipping": 0.71,
     "color": [
       "Red"
     ],
@@ -41347,7 +43224,7 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.07,
+    "marketPrice": 0.08,
     "lowestPriceWithShipping": 0.01,
     "color": [
       "Red"
@@ -41371,8 +43248,8 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 2.13,
-    "lowestPriceWithShipping": 1.54,
+    "marketPrice": 1.91,
+    "lowestPriceWithShipping": 1.4,
     "color": [
       "Purple"
     ],
@@ -41397,7 +43274,7 @@
     "rarityName": [
       "Uncommon"
     ],
-    "marketPrice": 0.06,
+    "marketPrice": 0.07,
     "lowestPriceWithShipping": 0.02,
     "color": [
       "Purple"
@@ -41423,7 +43300,7 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.29,
+    "marketPrice": 0.42,
     "lowestPriceWithShipping": 0.2,
     "color": [
       "Blue"
@@ -41448,8 +43325,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 16.13,
-    "lowestPriceWithShipping": 16.7,
+    "marketPrice": 24.17,
+    "lowestPriceWithShipping": 21,
     "color": [
       "Blue"
     ],
@@ -41474,7 +43351,7 @@
       "Common"
     ],
     "marketPrice": 0.2,
-    "lowestPriceWithShipping": 0.09,
+    "lowestPriceWithShipping": 0.12,
     "color": [
       "Purple"
     ],
@@ -41500,7 +43377,7 @@
       "Leader"
     ],
     "marketPrice": 0.16,
-    "lowestPriceWithShipping": 0.09,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Purple",
       "Black"
@@ -41526,8 +43403,8 @@
     "rarityName": [
       "Leader"
     ],
-    "marketPrice": 46.47,
-    "lowestPriceWithShipping": 41.86,
+    "marketPrice": 78.49,
+    "lowestPriceWithShipping": 61.59,
     "color": [
       "Purple"
     ],
@@ -41552,8 +43429,8 @@
     "rarityName": [
       "Common"
     ],
-    "marketPrice": 0.13,
-    "lowestPriceWithShipping": 0.01,
+    "marketPrice": 0.12,
+    "lowestPriceWithShipping": 0.1,
     "color": [
       "Yellow"
     ],
@@ -41578,8 +43455,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 0.91,
-    "lowestPriceWithShipping": 0.49,
+    "marketPrice": 0.64,
+    "lowestPriceWithShipping": 0.43,
     "color": [
       "Purple"
     ],
@@ -41603,8 +43480,8 @@
     "rarityName": [
       "Rare"
     ],
-    "marketPrice": 26.94,
-    "lowestPriceWithShipping": 26.98,
+    "marketPrice": 28.1,
+    "lowestPriceWithShipping": 28.1,
     "color": [
       "Purple"
     ],

--- a/scripts/scrapeOpCardPicsWithJson.js
+++ b/scripts/scrapeOpCardPicsWithJson.js
@@ -1,0 +1,53 @@
+const axios = require('axios');
+const fs = require('fs');
+const path = require('path');
+
+const imagesDir = path.join(__dirname, '../images');
+if (!fs.existsSync(imagesDir)){
+    fs.mkdirSync(imagesDir);
+}
+
+const downloadImage = async (url, path) => {
+    return axios({
+        url,
+        responseType: 'stream',
+    }).then(response =>
+        new Promise((resolve, reject) => {
+            response.data
+                .pipe(fs.createWriteStream(path))
+                .on('finish', () => resolve())
+                .on('error', e => reject(e));
+        }),
+    );
+};
+
+const downloadCardImages = async () => {
+    try {
+        const data = await fs.promises.readFile(path.join(__dirname, '../cards.json'), 'utf8');
+        const cards = JSON.parse(data);
+
+        for (const card of cards) {
+            const imageUrl = `https://product-images.tcgplayer.com/fit-in/411x411/${card.productId}.jpg`;
+            if (!imageUrl) {
+                console.log(`No image URL for ${card.productName}, skipping.`);
+                continue;
+            }
+
+            const filename = `${card.productId}.jpg`;
+            const imagePath = path.join(imagesDir, filename);
+
+            console.log(`Downloading image for ${card.productName}...`);
+            await downloadImage(imageUrl, imagePath).then(() => {
+                console.log(`Image for ${card.productName} downloaded successfully.`);
+            }).catch(error => {
+                console.error(`Failed to download image for ${card.productName}: ${error}`);
+            });
+        }
+
+        console.log('All images have been downloaded.');
+    } catch (error) {
+        console.error('Failed to download images:', error);
+    }
+};
+
+downloadCardImages();

--- a/scripts/scrapeOpCardPicsWithJson.js
+++ b/scripts/scrapeOpCardPicsWithJson.js
@@ -2,6 +2,8 @@ const axios = require('axios');
 const fs = require('fs');
 const path = require('path');
 
+const imageType = 'jpg'; // jpg, png, tiff, webp, svg
+
 const imagesDir = path.join(__dirname, '../images');
 if (!fs.existsSync(imagesDir)){
     fs.mkdirSync(imagesDir);
@@ -27,11 +29,7 @@ const downloadCardImages = async () => {
         const cards = JSON.parse(data);
 
         for (const card of cards) {
-            const imageUrl = `https://product-images.tcgplayer.com/fit-in/411x411/${card.productId}.jpg`;
-            if (!imageUrl) {
-                console.log(`No image URL for ${card.productName}, skipping.`);
-                continue;
-            }
+            const imageUrl = `https://product-images.tcgplayer.com/fit-in/411x411/${card.productId}.${imageType}`;
 
             const filename = `${card.productId}.jpg`;
             const imagePath = path.join(imagesDir, filename);


### PR DESCRIPTION
Add script to scrape card pics using JSON metadata we get from the `scrapeOpCards.js` script.

Works for all products in the JSON file except the `500 Years in the Future` products